### PR TITLE
jwt.ValidationError didn't not implement error

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -172,7 +172,7 @@ type ValidationError struct {
 }
 
 // Validation error is an error type
-func (e *ValidationError) Error() string {
+func (e ValidationError) Error() string {
 	if e.err == "" {
 		return "Token is invalid"
 	}


### PR DESCRIPTION
I tried to type assert the err from jwt.Parse() and got this

```
./main.go:135: impossible type assertion:
    jwt.ValidationError does not implement error (Error method has pointer receiver)
```

this fixes it and makes the Errors field accessible.
