### PR TITLE
Update jwt.go

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -151,9 +151,8 @@ func Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 
 		return token, vErr
 
-	} else {
-		return nil, &ValidationError{err: "Token contains an invalid number of segments", Errors: ValidationErrorMalformed}
 	}
+	return nil, &ValidationError{err: "Token contains an invalid number of segments", Errors: ValidationErrorMalformed}
 }
 
 // The errors that might occur when parsing and validating a token


### PR DESCRIPTION
Hi! I'm using Go 1.0.2 and encountered "src/github.com/dgrijalva/jwt-go/jwt.go:87: function ends without a return statement". This commit returns explicit at the end of the function.
