### PR TITLE
ParseFromRequest url param token=

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -217,6 +217,12 @@ func ParseFromRequest(req *http.Request, keyFunc Keyfunc) (token *Token, err err
 	if tokStr := req.Form.Get("access_token"); tokStr != "" {
 		return Parse(tokStr, keyFunc)
 	}
+	
+	// Look for "token=" url parameter
+	param := req.URL.Query()
+	if tokStr := param.Get("token"); tokStr != "" {
+		return Parse(tokStr, keyFunc)
+	}
 
 	return nil, ErrNoTokenInRequest
 


### PR DESCRIPTION
Added a check for a token parameter in the url inside ParseFromRequest. Not entirely sure if this is a standard thing to need for jwt, however it was useful for my use case. 

example:
http://mysite.com/somewhere/?token=TOKEN

