### PR TITLE
make sure everything is copied to the hasher

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -5,6 +5,8 @@ import (
 	"crypto"
 	"crypto/hmac"
 	"errors"
+	"io"
+	"strings"
 )
 
 // Implements the HMAC-SHA family of signing methods signing methods
@@ -55,7 +57,10 @@ func (m *SigningMethodHMAC) Verify(signingString, signature string, key interfac
 			}
 
 			hasher := hmac.New(m.Hash.New, keyBytes)
-			hasher.Write([]byte(signingString))
+			_, err = io.Copy(hasher, strings.NewReader(signingString))
+			if err != nil {
+				return err
+			}
 
 			if !bytes.Equal(sig, hasher.Sum(nil)) {
 				err = ErrSignatureInvalid
@@ -74,7 +79,10 @@ func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) (string,
 		}
 
 		hasher := hmac.New(m.Hash.New, keyBytes)
-		hasher.Write([]byte(signingString))
+		_, err := io.Copy(hasher, strings.NewReader(signingString))
+		if err != nil {
+			return "", err
+		}
 
 		return EncodeSegment(hasher.Sum(nil)), nil
 	}

--- a/rsa.go
+++ b/rsa.go
@@ -4,6 +4,8 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"io"
+	"strings"
 )
 
 // Implements the RSA family of signing methods signing methods
@@ -73,7 +75,10 @@ func (m *SigningMethodRSA) Verify(signingString, signature string, key interface
 		return ErrHashUnavailable
 	}
 	hasher := m.Hash.New()
-	hasher.Write([]byte(signingString))
+	_, err = io.Copy(hasher, strings.NewReader(signingString))
+	if err != nil {
+		return err
+	}
 
 	// Verify the signature
 	return rsa.VerifyPKCS1v15(rsaKey, m.Hash, hasher.Sum(nil), sig)
@@ -103,7 +108,10 @@ func (m *SigningMethodRSA) Sign(signingString string, key interface{}) (string, 
 	}
 
 	hasher := m.Hash.New()
-	hasher.Write([]byte(signingString))
+	_, err = io.Copy(hasher, strings.NewReader(signingString))
+	if err != nil {
+		return "", err
+	}
 
 	// Sign the string and return the encoded bytes
 	if sigBytes, err := rsa.SignPKCS1v15(rand.Reader, rsaKey, m.Hash, hasher.Sum(nil)); err == nil {


### PR DESCRIPTION
I'm not sure why these writes would fail or fall short but before we start to look at the `n` return value of the `Write()` calls I modified these to use `io.Copy()` and the errors should be checked regardless.

ps: I found another unchecked error (by using [errcheck](https://github.com/kisielk/errcheck)) [here](https://github.com/dgrijalva/jwt-go/blob/1663b3c6c2dc6f50d23fdbbfece59ebd7fc4157a/jwt.go#L216) but that's okay, I guess.
