### PR TITLE
Create constants for the strings representing different signing methods.

### DIFF
--- a/signing_method.go
+++ b/signing_method.go
@@ -2,6 +2,15 @@ package jwt
 
 var signingMethods = map[string]func() SigningMethod{}
 
+const (
+	RS256 = "RS256"
+	RS384 = "RS384"
+	RS512 = "RS512"
+	HS256 = "HS256"
+	HS384 = "HS384"
+	HS512 = "HS512"
+)
+
 // Signing method
 type SigningMethod interface {
 	Verify(signingString, signature string, key interface{}) error


### PR DESCRIPTION
In general, you should never really use strings to identify objects by name. Using strings in this way introduces new opportunities for typos and errors.
1. It's easy to make a typo while typing the name of a string.
2. You won't find out there was a typo until runtime.
3. Your text editor/IDE can't help you out by offering autocomplete suggestions, since it doesn't know which strings are valid.

The changes I made are a compromise which maintains backwards compatibility. The following code is still completely valid:

``` go
// Create the token
token := jwt.New(jwt.GetSigningMethod("HS256"))
```

However, I would suggest using this style of code for the reasons listed above:

``` go
// Create the token
token := jwt.New(jwt.GetSigningMethod(jwt.HS256))
```

If you are willing to break backwards compatibility here, there are even better ways of doing it. Take a look at how the [base64 package](http://golang.org/pkg/encoding/base64/) in the stdlib deals with different encoding types.

There's no real need for the `GetSigningMethod` function. Instead you could have an SigningMethod type (an interface might work too), and several different instantiations of that type (or implementations of an interface), one for each signing method. Then you could reference the signing methods  directly by name. Here's an example of what that might look like:

``` go
 // Create the token
 token := jwt.HS256Encoding.New()
```

IMO this version is much cleaner, and eliminates the need for the [map of string name to signing method](https://github.com/dgrijalva/jwt-go/blob/master/signing_method.go#L3), as well as the [RegisterSigningMethod](https://github.com/dgrijalva/jwt-go/blob/master/signing_method.go#L14) and [GetSigningMethod](https://github.com/dgrijalva/jwt-go/blob/master/signing_method.go#L19) functions.

Let me know your thoughts wrt backwards compatibility. If you want to accept this PR as is, let me first update the README and anywhere else in the code that uses GetSigningMethod too. If you want to explore that second option I mentioned or make other changes I'd be happy to help however I can!
