### PR TITLE
Reference signing methods directly instead of by a string name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Parsing and verifying tokens is pretty straight forward.  You pass in the token 
 
 ```go
 	// Create the token
-	token := jwt.New(jwt.GetSigningMethod("HS256"))
+	token := jwt.New(SigningMethodHS256)
 	// Set some claims
 	token.Claims["foo"] = "bar"
 	token.Claims["exp"] = time.Now().Add(time.Hour * 72).Unix()

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -104,7 +104,7 @@ func makeSample(c map[string]interface{}) string {
 		panic(e.Error())
 	}
 
-	token := New(GetSigningMethod("RS256"))
+	token := New(SigningMethodRS256)
 	token.Claims = c
 	s, e := token.SignedString(key)
 

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -80,14 +80,13 @@ func TestRSASign(t *testing.T) {
 
 func TestRSAVerifyWithPreParsedPrivateKey(t *testing.T) {
 	key, _ := ioutil.ReadFile("test/sample_key.pub")
-	method := GetSigningMethod("RS256").(*SigningMethodRSA)
 	parsedKey, err := ParseRSAPublicKeyFromPEM(key)
 	if err != nil {
 		t.Fatal(err)
 	}
 	testData := rsaTestData[0]
 	parts := strings.Split(testData.tokenString, ".")
-	err = method.Verify(strings.Join(parts[0:2], "."), parts[2], parsedKey)
+	err = SigningMethodRS256.Verify(strings.Join(parts[0:2], "."), parts[2], parsedKey)
 	if err != nil {
 		t.Errorf("[%v] Error while verifying key: %v", testData.name, err)
 	}
@@ -95,14 +94,13 @@ func TestRSAVerifyWithPreParsedPrivateKey(t *testing.T) {
 
 func TestRSAWithPreParsedPrivateKey(t *testing.T) {
 	key, _ := ioutil.ReadFile("test/sample_key")
-	method := GetSigningMethod("RS256").(*SigningMethodRSA)
 	parsedKey, err := ParseRSAPrivateKeyFromPEM(key)
 	if err != nil {
 		t.Fatal(err)
 	}
 	testData := rsaTestData[0]
 	parts := strings.Split(testData.tokenString, ".")
-	sig, err := method.Sign(strings.Join(parts[0:2], "."), parsedKey)
+	sig, err := SigningMethodRS256.Sign(strings.Join(parts[0:2], "."), parsedKey)
 	if err != nil {
 		t.Errorf("[%v] Error signing token: %v", testData.name, err)
 	}


### PR DESCRIPTION
First, let me say that this is a great library! I've been using it in a project for the past
week or so and have pretty much no complaints. Thank you!

I made the following change:

When possible, instead of identifying signing methods by string, pass
them in directly by name. This is less error-prone and avoids an unnecessary
map lookup. Also encourage this type of usage by using it in the README.
### What?

I replaced several instances of code like this:

``` go
token := jwt.New(jwt.GetSigningMethod("HS256"))
```

With this:

``` go
token := jwt.New(SigningMethodHS256)
```
### Why?

When parsing a jwt token, you have to use the string name of a signing method, since
that is what is encoded into the "alg" claim in the token. However, this is not always necessary.
When you're not parsing a token, it is better to reference the signing methods directly instead of
using a string identifiers.
1. Your text editor/IDE does not know how to autocomplete a string.
2. If you make a typo with the string name, it's a runtime error. But if you make a typo with
   the signing method name (the object itself), it's a compile-time error. Catching errors faster is better.
3. This avoids an unnecessary lookup in the signing methods map. Making code simpler and giving
   (slightly) better performance.
4. It turns out to use less characters and less function calls.

I understand this is a pretty small change (maybe even seemingly insignificant). But I consider this
a small improvement to an already good library, and I don't see any downsides. I would greatly appreciate
it if you accept this.

Cheers!
