### PR TITLE
Fix timing side-channel attack in hmac comparison

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -1,7 +1,6 @@
 package jwt
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/hmac"
 	"errors"
@@ -57,7 +56,7 @@ func (m *SigningMethodHMAC) Verify(signingString, signature string, key interfac
 			hasher := hmac.New(m.Hash.New, keyBytes)
 			hasher.Write([]byte(signingString))
 
-			if !bytes.Equal(sig, hasher.Sum(nil)) {
+			if !hmac.Equal(sig, hasher.Sum(nil)) {
 				err = ErrSignatureInvalid
 			}
 		}


### PR DESCRIPTION
From the [crypto/hmac documentation](https://godoc.org/crypto/hmac):

>  Receivers should be careful to use Equal to compare MACs in order to avoid timing side-channels: 

``` go
// CheckMAC returns true if messageMAC is a valid HMAC tag for message.
func CheckMAC(message, messageMAC, key []byte) bool {
    mac := hmac.New(sha256.New, key)
    mac.Write(message)
    expectedMAC := mac.Sum(nil)
    return hmac.Equal(messageMAC, expectedMAC)
}
```

In this library, `SigningMethodHMAC` currently uses `bytes.Equal` rather than the constant-time `hmac.Equal`. Very easy to fix; this just swaps out for the correct method.
