### PR TITLE
Updated token creation example to use the proper method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Parsing and verifying tokens is pretty straight forward.  You pass in the token 
 
 ```go
 	// Create the token
-	token := jwt.New(SigningMethodHS256)
+	token := jwt.New(jwt.SigningMethodHS256)
 	// Set some claims
 	token.Claims["foo"] = "bar"
 	token.Claims["exp"] = time.Now().Add(time.Hour * 72).Unix()


### PR DESCRIPTION
Example broke with error `undefined: SigningMethodHS256`. Edited to use jwt.SigningMethodHS256