### PR TITLE
Create a ParseFromRequestHeader() function

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,9 +6,10 @@ import (
 
 // Error constants
 var (
-	ErrInvalidKey       = errors.New("key is invalid or of invalid type")
-	ErrHashUnavailable  = errors.New("the requested hash function is unavailable")
-	ErrNoTokenInRequest = errors.New("no token present in request")
+	ErrInvalidKey             = errors.New("key is invalid or of invalid type")
+	ErrHashUnavailable        = errors.New("the requested hash function is unavailable")
+	ErrNoTokenInRequest       = errors.New("no token present in request")
+	ErrNoTokenInRequestHeader = errors.New("no token present in request header")
 )
 
 // The errors that might occur when parsing and validating a token

--- a/jwt.go
+++ b/jwt.go
@@ -180,7 +180,23 @@ func ParseFromRequest(req *http.Request, keyFunc Keyfunc) (token *Token, err err
 	}
 
 	return nil, ErrNoTokenInRequest
+}
 
+// ParseFromRequestHeader performs the same function as ParseFromRequest, but
+// limits the check to the header.  This is done because the call to
+// req.ParseMultipartForm() can change the body of the request, which affects
+// other functions that read in the request body later on.
+func ParseFromRequestHeader(req *http.Request, keyFunc Keyfunc) (token *Token, err error) {
+
+	// Look for an Authorization header.
+	if ah := req.Header.Get("Authorization"); ah != "" {
+		// Check if it's not a bearer token
+		if len(ah) <= 6 || strings.ToUpper(ah[0:6]) != "BEARER" {
+			return nil, ErrNoTokenInRequestHeader
+		}
+	}
+	// Is a bearer token, so parse it.
+	return Parse(ah[7:], keyFunc)
 }
 
 // Encode JWT specific base64url encoding with padding stripped

--- a/jwt.go
+++ b/jwt.go
@@ -188,15 +188,15 @@ func ParseFromRequest(req *http.Request, keyFunc Keyfunc) (token *Token, err err
 // other functions that read in the request body later on.
 func ParseFromRequestHeader(req *http.Request, keyFunc Keyfunc) (token *Token, err error) {
 
-	// Look for an Authorization header.
+	// Look for an Authorization header
 	if ah := req.Header.Get("Authorization"); ah != "" {
-		// Check if it's not a bearer token
-		if len(ah) <= 6 || strings.ToUpper(ah[0:6]) != "BEARER" {
-			return nil, ErrNoTokenInRequestHeader
+		// Check if it's a bearer token
+		if len(ah) > 6 && strings.ToUpper(ah[0:6]) == "BEARER" {
+			return Parse(ah[7:], keyFunc)
 		}
 	}
-	// Is a bearer token, so parse it.
-	return Parse(ah[7:], keyFunc)
+
+	return nil, ErrNoTokenInRequestHeader
 }
 
 // Encode JWT specific base64url encoding with padding stripped


### PR DESCRIPTION
Right now, `ParseFromRequest()` checks the request.Body via `request.ParseMultipartForm()` if the token is not found in the header.  The problem is that ParseMultipartForm has the nasty side-effect of modifying the body of the request.

In some situations this can lead to problems working with the request in later, and so this proposed function gives the option of only checking the header.

In my case I was using a JWT for authentication in middleware, which was then affecting the contents of an POST request with an image in the body.  Using the header only function solved the problem for me.