### PR TITLE
Update list of signing algorithms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,19 @@ The part in the middle is the interesting bit.  It's called the Claims and conta
 
 ## What's in the box?
 
-This library supports the parsing and verification as well as the generation and signing of JWTs.  Current supported signing algorithms are RSA256 and HMAC SHA256, though hooks are present for adding your own.
+This library supports the parsing and verification as well as the generation and signing of JWTs. Current supported signing algorithms are:
+
+* ES256,
+* ES384,
+* ES512,
+* HMAC SHA256,
+* HMAC SHA384,
+* HMAC SHA512,
+* RS256,
+* RS384,
+* RS512,
+
+and hooks are present for adding your own.
 
 ## Parse and Verify
 


### PR DESCRIPTION
I checked [jwt.io](http://jwt.io/) and it seems to be outdated for me (based on the implementation). I've updated the `README.md` to reflect the supported algorithms. Please review my PR. I'll send a PR to [jsonwebtoken/jsonwebtoken.github.io](https://github.com/jsonwebtoken/jsonwebtoken.github.io) too, if this one gets merged.