### PR TITLE
test with go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: go
 go:
   - 1.3.3
   - 1.4.2
+  - 1.5
+  - tip


### PR DESCRIPTION
Added '- tip' as well so it always tests with the latest version of go