### PR TITLE
Add support for Signing using AppEngine

### DIFF
--- a/appengine.go
+++ b/appengine.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func (s *SigningMethodAppEngine) Alg() string {
-	return "RS256"
+	return "AppEngine"
 }
 
 // Implements the Sign method from SigningMethod

--- a/appengine.go
+++ b/appengine.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func (s *SigningMethodAppEngine) Alg() string {
-	return "AppEngine"
+	return "RS256"
 }
 
 // Implements the Sign method from SigningMethod

--- a/appengine.go
+++ b/appengine.go
@@ -1,0 +1,95 @@
+// +build appengine
+
+package jwt
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+
+	"appengine"
+)
+
+// Implements the built-in AppEngine signing method
+// This method uses a private key unique to your AppEngine
+// application and the key may rotate from time to time.
+// https://cloud.google.com/appengine/docs/go/reference#SignBytes
+// https://cloud.google.com/appengine/docs/go/appidentity/#Go_Asserting_identity_to_other_systems
+type SigningMethodAppEngine struct{}
+
+type certificates []appengine.Certificate
+
+func init() {
+	RegisterSigningMethod("AppEngine", func() SigningMethod {
+		return &SigningMethodAppEngine{}
+	})
+}
+
+func (s *SigningMethodAppEngine) Alg() string {
+	return "AppEngine"
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, a valid appengine.Context must be
+// passed as the key.
+func (s *SigningMethodAppEngine) Sign(signingString string, key interface{}) (string, error) {
+	var ctx appengine.Context
+
+	switch k := key.(type) {
+	case appengine.Context:
+		ctx = k
+	default:
+		return "", ErrInvalidKey
+	}
+
+	_, signature, err := appengine.SignBytes(ctx, []byte(signingString))
+
+	if err != nil {
+		return "", err
+	}
+
+	return EncodeSegment(signature), nil
+}
+
+// Implements the Verify method from SigningMethod
+// For this signing method, a valid appengine.Context must be
+// passed as the key.
+func (s *SigningMethodAppEngine) Verify(signingString, signature string, key interface{}) error {
+	var ctx appengine.Context
+
+	switch k := key.(type) {
+	case appengine.Context:
+		ctx = k
+	default:
+		return ErrInvalidKey
+	}
+
+	var sig []byte
+	var err error
+	if sig, err = DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	var certs certificates
+	certs, err = appengine.PublicCertificates(ctx)
+	if err != nil {
+		return err
+	}
+
+	hasher := sha256.New()
+	hasher.Write([]byte(signingString))
+
+	var certErr error
+	for _, cert := range certs {
+		rsaKey, err := ParseRSAPublicKeyFromPEM(cert.Data)
+		if err != nil {
+			return err
+		}
+
+		if certErr = rsa.VerifyPKCS1v15(rsaKey, crypto.SHA256, hasher.Sum(nil), sig); certErr == nil {
+			return nil
+		}
+	}
+
+	return certErr
+}

--- a/appengine_test.go
+++ b/appengine_test.go
@@ -1,0 +1,81 @@
+// +build appengine
+
+package jwt_test
+
+import (
+	"strings"
+	"testing"
+
+	"appengine/aetest"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// Public/Private key is hardcoded in dev server and found in
+// google.appengine.api.app_identity.app_identity_stub
+
+var appEngineTestData = []struct {
+	name        string
+	tokenString string
+	alg         string
+	claims      map[string]interface{}
+	valid       bool
+}{
+	{
+		"AppEngine",
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.YgMNm6dQvP0H5ZQC6xheyzCJ7tuz3BYh6YMNVCDNHX58zgbodNVRMgR26hpCtxvnXkz-98Qd_lHcbCeIr8dWLNmt_EOLYXgTTnYoy8qCwnOFj62wnIBamxo684HIDbkoGk3rblbu8LIVA4cPm0_dFnyCcHM1hMao_HhaAb9rxVYA923q2Oi1-MhoVRbpTnru2GNvp8SzWR1KSPFedtxnr9K4iEv8jnuMHIgtvY1FVOxRCTHF6Whqq-YrD0ruqwpEYhMzPPTkqN5KB7EOjg-Am72DPH-eH8aQ40yju-Jb8knVj0IFfbrZl7UhPJ2Gz2WGkAi7aeeUnNIPdUkuS3gd5w",
+		"AppEngine",
+		map[string]interface{}{"foo": "bar"},
+		true,
+	},
+	{
+		"basic invalid: foo => bar",
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.EhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		"AppEngine",
+		map[string]interface{}{"foo": "bar"},
+		false,
+	},
+}
+
+func TestAppEngineVerify(t *testing.T) {
+	c, err := aetest.NewContext(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	for _, data := range appEngineTestData {
+		parts := strings.Split(data.tokenString, ".")
+
+		method := jwt.GetSigningMethod(data.alg)
+		err := method.Verify(strings.Join(parts[0:2], "."), parts[2], c)
+		if data.valid && err != nil {
+			t.Errorf("[%v] Error while verifying key: %v", data.name, err)
+		}
+		if !data.valid && err == nil {
+			t.Errorf("[%v] Invalid key passed validation", data.name)
+		}
+	}
+}
+
+func TestAppEngineSign(t *testing.T) {
+	c, err := aetest.NewContext(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	for _, data := range appEngineTestData {
+		if data.valid {
+			parts := strings.Split(data.tokenString, ".")
+			method := jwt.GetSigningMethod(data.alg)
+			sig, err := method.Sign(strings.Join(parts[0:2], "."), c)
+			if err != nil {
+				t.Errorf("[%v] Error signing token: %v", data.name, err)
+			}
+			if sig != parts[2] {
+				t.Errorf("[%v] Incorrect signature.\nwas:\n%v\nexpecting:\n%v", data.name, sig, parts[2])
+			}
+		}
+	}
+}


### PR DESCRIPTION
This may not be relevant for this project's goals, but I've decided to use this package in my AppEngine application and AppEngine has a convenient/secure way of signing bytes. The key management is handled by Google and can rotate. It is unique per application.

I know I set the `Alg` to `AppEngine` which isn't up to spec, but AppEngine uses RS256 which is already defined in the package and I didn't want to make a conflict. Defining the algorithm in the header has proven to be insecure anyway and some have suggested to remove its usage altogether, so I'm not sure how big of an issue this would be.

Hopefully this is found to be useful and becomes a part of this package. If it doesn't fit this project's goals, then I understand why this PR might be rejected.

Thank you.