### PR TITLE
Vulnerability Fix

### DIFF
--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -5,7 +5,9 @@
 * Dropped support for `[]byte` keys when using RSA signing methods.  This convenience feature could contribute to security vulnerabilities involving mismatched key types with signing methods.
 * Added `Claims` interface type to allow users to decode the claims into a custom type
 * The `Claims` property on `Token` is now type `Claims` instead of `map[string]interface{}`.  The default value is type `MapClaims`, which is an alias to `map[string]interface{}`.  This makes it possible to use a custom type when decoding claims.
-* Added `ParseWithClaims`, which takes a third argument of type `Claims`.  Use this function instead of `Parse` if you have a custom type you'd like to decode into.
+* Parameters are passed in jwt.ParseParam structure. This allows for variable number of parameters
+* Checking for specific Method in headers as part of Vulnerability Fix highlighted by Tim McClean in the article below
+* https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
 
 #### 2.3.0
 

--- a/cmd/jwt/app.go
+++ b/cmd/jwt/app.go
@@ -115,9 +115,10 @@ func verifyToken() error {
 	}
 
 	// Parse the token.  Load the key from command line option
-	token, err := jwt.Parse(string(tokData), func(t *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(jwt.ParseParam{TokenString: string(tokData), Method: jwt.SigningMethodRS256,
+		KeyFunc: func(t *jwt.Token) (interface{}, error) {
 		return loadData(*flagKey)
-	})
+	}})
 
 	// Print some debug data
 	if *flagDebug && token != nil {

--- a/errors.go
+++ b/errors.go
@@ -25,6 +25,7 @@ const (
 	ValidationErrorNotValidYet   // NBF validation failed
 	ValidationErrorId            // JTI validation failed
 	ValidationErrorClaimsInvalid // Generic claims validation error
+	ValidationErrorAlgInvalid // Alg validation error
 )
 
 // The error from Parse if token is not valid

--- a/example_test.go
+++ b/example_test.go
@@ -8,9 +8,12 @@ import (
 )
 
 func ExampleParse(myToken string, myLookupKey func(interface{}) (interface{}, error)) {
-	token, err := jwt.Parse(myToken, func(token *jwt.Token) (interface{}, error) {
-		return myLookupKey(token.Header["kid"])
-	})
+	token, err := jwt.Parse(jwt.ParseParam{
+		TokenString: myToken,
+		Method: jwt.SigningMethodRS256,
+		KeyFunc: func(token *jwt.Token) (interface{}, error) {
+			return myLookupKey(token.Header["kid"])
+		}})
 
 	if err == nil && token.Valid {
 		fmt.Println("Your token is valid.  I like your style.")
@@ -71,9 +74,12 @@ func ExampleNewWithClaims_customType() {
 }
 
 func ExampleParse_errorChecking(myToken string, myLookupKey func(interface{}) (interface{}, error)) {
-	token, err := jwt.Parse(myToken, func(token *jwt.Token) (interface{}, error) {
-		return myLookupKey(token.Header["kid"])
-	})
+	token, err := jwt.Parse(jwt.ParseParam{
+		TokenString: myToken,
+		Method: jwt.SigningMethodRS256,
+		KeyFunc: func(token *jwt.Token) (interface{}, error) {
+			return myLookupKey(token.Header["kid"])
+		}})
 
 	if token.Valid {
 		fmt.Println("You look nice today")

--- a/jwt.go
+++ b/jwt.go
@@ -140,7 +140,7 @@ func Parse(parseParam ParseParam) (*Token, error) {
 		if token.Method = GetSigningMethod(method); token.Method == nil {
 			return token, &ValidationError{err: "signing method (alg) is unavailable.", Errors: ValidationErrorUnverifiable}
 		} else if token.Method.Alg() != parseParam.Method.Alg() {
-			return token, &ValidationError{err: "Header contains invalid method (alg).", Errors: ValidationErrorUnverifiable}
+			return token, &ValidationError{err: "Header contains invalid method (alg).", Errors: ValidationErrorAlgInvalid}
 		}
 	} else {
 		return token, &ValidationError{err: "signing method (alg) is unspecified.", Errors: ValidationErrorUnverifiable}

--- a/jwt.go
+++ b/jwt.go
@@ -19,6 +19,18 @@ var TimeFunc = time.Now
 // Header of the token (such as `kid`) to identify which key to use.
 type Keyfunc func(*Token) (interface{}, error)
 
+// Variable Number of Parameters
+// Introducing variable number of parameters to accommodate fixes for vulnerability
+// Using this feature to fix a vulnerability raised by Tim McClean in his article dated 31 March 2015
+// https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+type ParseParam struct {
+	TokenString string
+	KeyFunc Keyfunc
+	Method SigningMethod
+	Req *http.Request
+	Claims Claims
+}
+
 // A JWT Token.  Different fields will be used depending on whether you're
 // creating or parsing/verifying a token.
 type Token struct {
@@ -86,19 +98,19 @@ func (t *Token) SigningString() (string, error) {
 // Parse, validate, and return a token.
 // keyFunc will receive the parsed token and should return the key for validating.
 // If everything is kosher, err will be nil
-func Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
-	return ParseWithClaims(tokenString, keyFunc, MapClaims{})
-}
 
-func ParseWithClaims(tokenString string, keyFunc Keyfunc, claims Claims) (*Token, error) {
-	parts := strings.Split(tokenString, ".")
+func Parse(parseParam ParseParam) (*Token, error) {
+	if parseParam.Method == nil {
+		return nil, &ValidationError{err: "Must pass verification method (alg).", Errors: ValidationErrorUnverifiable}
+	}
+	parts := strings.Split(parseParam.TokenString, ".")
 	if len(parts) != 3 {
 		return nil, &ValidationError{err: "token contains an invalid number of segments", Errors: ValidationErrorMalformed}
 	}
 
 	var err error
 	token := &Token{
-		Raw: tokenString,
+		Raw: parseParam.TokenString,
 	}
 
 	// parse Header
@@ -117,16 +129,18 @@ func ParseWithClaims(tokenString string, keyFunc Keyfunc, claims Claims) (*Token
 		return token, &ValidationError{err: err.Error(), Errors: ValidationErrorMalformed}
 	}
 
-	if err = json.Unmarshal(claimBytes, &claims); err != nil {
+	if err = json.Unmarshal(claimBytes, &parseParam.Claims); err != nil {
 		return token, &ValidationError{err: err.Error(), Errors: ValidationErrorMalformed}
 	}
 
-	token.Claims = claims
+	token.Claims = parseParam.Claims
 
 	// Lookup signature method
 	if method, ok := token.Header["alg"].(string); ok {
 		if token.Method = GetSigningMethod(method); token.Method == nil {
 			return token, &ValidationError{err: "signing method (alg) is unavailable.", Errors: ValidationErrorUnverifiable}
+		} else if token.Method.Alg() != parseParam.Method.Alg() {
+			return token, &ValidationError{err: "Header contains invalid method (alg).", Errors: ValidationErrorUnverifiable}
 		}
 	} else {
 		return token, &ValidationError{err: "signing method (alg) is unspecified.", Errors: ValidationErrorUnverifiable}
@@ -134,11 +148,11 @@ func ParseWithClaims(tokenString string, keyFunc Keyfunc, claims Claims) (*Token
 
 	// Lookup key
 	var key interface{}
-	if keyFunc == nil {
+	if parseParam.KeyFunc == nil {
 		// keyFunc was not provided.  short circuiting validation
 		return token, &ValidationError{err: "no Keyfunc was provided.", Errors: ValidationErrorUnverifiable}
 	}
-	if key, err = keyFunc(token); err != nil {
+	if key, err = parseParam.KeyFunc(token); err != nil {
 		// keyFunc returned an error
 		return token, &ValidationError{err: err.Error(), Errors: ValidationErrorUnverifiable}
 	}
@@ -175,23 +189,20 @@ func ParseWithClaims(tokenString string, keyFunc Keyfunc, claims Claims) (*Token
 // This method will call ParseMultipartForm if there's no token in the header.
 // Currently, it looks in the Authorization header as well as
 // looking for an 'access_token' request parameter in req.Form.
-func ParseFromRequest(req *http.Request, keyFunc Keyfunc) (token *Token, err error) {
-	return ParseFromRequestWithClaims(req, keyFunc, MapClaims{})
-}
 
-func ParseFromRequestWithClaims(req *http.Request, keyFunc Keyfunc, claims Claims) (token *Token, err error) {
+func ParseFromRequest(parseParam ParseParam) (token *Token, err error) {
 	// Look for an Authorization header
-	if ah := req.Header.Get("Authorization"); ah != "" {
+	if ah := parseParam.Req.Header.Get("Authorization"); ah != "" {
 		// Should be a bearer token
 		if len(ah) > 6 && strings.ToUpper(ah[0:6]) == "BEARER" {
-			return ParseWithClaims(ah[7:], keyFunc, claims)
+			return Parse(ParseParam{TokenString: ah[7:], Method: parseParam.Method, KeyFunc: parseParam.KeyFunc, Claims: parseParam.Claims})
 		}
 	}
 
 	// Look for "access_token" parameter
-	req.ParseMultipartForm(10e6)
-	if tokStr := req.Form.Get("access_token"); tokStr != "" {
-		return ParseWithClaims(tokStr, keyFunc, claims)
+	parseParam.Req.ParseMultipartForm(10e6)
+	if tokStr := parseParam.Req.Form.Get("access_token"); tokStr != "" {
+		return Parse(ParseParam{TokenString: tokStr, Method: parseParam.Method, KeyFunc: parseParam.KeyFunc, Claims: parseParam.Claims})
 	}
 
 	return nil, ErrNoTokenInRequest

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -39,6 +39,15 @@ var jwtTestData = []struct {
 		0,
 	},
 	{
+		"basic",
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		jwt.SigningMethodRS256,
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar"},
+		true,
+		0,
+	},
+	{
 		"basic expired",
 		"", // autogen
 		jwt.SigningMethodRS256,

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -23,6 +23,7 @@ var (
 var jwtTestData = []struct {
 	name        string
 	tokenString string
+	method 		jwt.SigningMethod
 	keyfunc     jwt.Keyfunc
 	claims      jwt.MapClaims
 	valid       bool
@@ -31,6 +32,7 @@ var jwtTestData = []struct {
 	{
 		"basic",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		jwt.SigningMethodRS256,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		true,
@@ -39,6 +41,7 @@ var jwtTestData = []struct {
 	{
 		"basic expired",
 		"", // autogen
+		jwt.SigningMethodRS256,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
 		false,
@@ -47,6 +50,7 @@ var jwtTestData = []struct {
 	{
 		"basic nbf",
 		"", // autogen
+		jwt.SigningMethodRS256,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
 		false,
@@ -55,6 +59,7 @@ var jwtTestData = []struct {
 	{
 		"expired and nbf",
 		"", // autogen
+		jwt.SigningMethodRS256,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100), "exp": float64(time.Now().Unix() - 100)},
 		false,
@@ -63,6 +68,7 @@ var jwtTestData = []struct {
 	{
 		"basic invalid",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.EhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		jwt.SigningMethodRS256,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -71,6 +77,7 @@ var jwtTestData = []struct {
 	{
 		"basic nokeyfunc",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		jwt.SigningMethodRS256,
 		nilKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -79,6 +86,7 @@ var jwtTestData = []struct {
 	{
 		"basic nokey",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		jwt.SigningMethodRS256,
 		emptyKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -87,6 +95,7 @@ var jwtTestData = []struct {
 	{
 		"basic errorkey",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		jwt.SigningMethodRS256,
 		errorKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -130,7 +139,9 @@ func TestJWT(t *testing.T) {
 			data.tokenString = makeSample(data.claims)
 		}
 
-		token, err := jwt.ParseWithClaims(data.tokenString, data.keyfunc, &jwt.MapClaims{})
+		token, err := jwt.Parse(jwt.ParseParam{TokenString: data.tokenString, Method: data.method,
+			KeyFunc: data.keyfunc,
+			Claims: &jwt.MapClaims{}})
 
 		if !reflect.DeepEqual(&data.claims, token.Claims) {
 			t.Errorf("[%v] Claims mismatch. Expecting: %v  Got: %v", data.name, data.claims, token.Claims)
@@ -167,7 +178,11 @@ func TestParseRequest(t *testing.T) {
 
 		r, _ := http.NewRequest("GET", "/", nil)
 		r.Header.Set("Authorization", fmt.Sprintf("Bearer %v", data.tokenString))
-		token, err := jwt.ParseFromRequestWithClaims(r, data.keyfunc, &jwt.MapClaims{})
+		token, err := jwt.ParseFromRequest(jwt.ParseParam{
+			Req: r,
+			Method: data.method,
+			KeyFunc: data.keyfunc,
+			Claims: &jwt.MapClaims{}})
 
 		if token == nil {
 			t.Errorf("[%v] Token was not found: %v", data.name, err)


### PR DESCRIPTION
This is a fix for the vulnerability highlighted by Tim McClean.
https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/ 

The Parse function takes in the parameters in jwt.ParseParam. The validation is done on the Alg passed in the Headers