### PR TITLE
json.Number instead of float64 for numeric values

### DIFF
--- a/cmd/jwt/app.go
+++ b/cmd/jwt/app.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 
 	"github.com/dgrijalva/jwt-go"
+	"bytes"
 )
 
 var (
@@ -155,8 +156,12 @@ func signToken() error {
 	}
 
 	// parse the JSON of the claims
-	var claims map[string]interface{}
-	if err := json.Unmarshal(tokData, &claims); err != nil {
+	var (
+		d = json.NewDecoder(bytes.NewReader(tokData))
+		claims map[string]interface{}
+	)
+	d.UseNumber()
+	if err := d.Decode(&claims); err != nil {
 		return fmt.Errorf("Couldn't parse claims JSON: %v", err)
 	}
 

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -1,11 +1,13 @@
 package jwt_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/dgrijalva/jwt-go"
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -38,7 +40,7 @@ var jwtTestData = []struct {
 		"basic expired",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
+		map[string]interface{}{"foo": "bar", "exp": json.Number(strconv.FormatInt(time.Now().Unix()-100, 10))},
 		false,
 		jwt.ValidationErrorExpired,
 	},
@@ -46,7 +48,7 @@ var jwtTestData = []struct {
 		"basic nbf",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
+		map[string]interface{}{"foo": "bar", "nbf": json.Number(strconv.FormatInt(time.Now().Unix()+100, 10))},
 		false,
 		jwt.ValidationErrorNotValidYet,
 	},
@@ -54,7 +56,7 @@ var jwtTestData = []struct {
 		"expired and nbf",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "nbf": float64(time.Now().Unix() + 100), "exp": float64(time.Now().Unix() - 100)},
+		map[string]interface{}{"foo": "bar", "nbf": json.Number(strconv.FormatInt(time.Now().Unix()+100, 10)), "exp": json.Number(strconv.FormatInt(time.Now().Unix()-100, 10))},
 		false,
 		jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired,
 	},


### PR DESCRIPTION
PR #68 fails to pass tests, but json.Number support is still mentioned in 3.0 milestone #75. This PR passes all tests and makes unmarshalling numerics into json.Number a default behaviour, which is, imho, a lot more flexible than single float64, not to mention that the last one also breaks long integers, which are used by JWT standard in nbf and exp fields, into something like 1.2423434e+07.