### PR TITLE
Use json.Number for claims check if parser.UseJSONNumber is true

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -87,17 +87,38 @@ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 	// Check expiration times
 	vErr := &ValidationError{}
 	now := TimeFunc().Unix()
-	if exp, ok := token.Claims["exp"].(float64); ok {
-		if now > int64(exp) {
-			vErr.err = "token is expired"
-			vErr.Errors |= ValidationErrorExpired
+	var exp, nbf int64
+	var vexp, vnbf bool
+
+	if p.UseJSONNumber {
+		if num, ok := token.Claims["exp"].(json.Number); ok {
+			if exp, err = num.Int64(); err == nil {
+				vexp = true
+			}
+		}
+		if num, ok := token.Claims["nbf"].(json.Number); ok {
+			if nbf, err = num.Int64(); err == nil {
+				vnbf = true
+			}
+		}
+	} else {
+		var ok bool
+		if exp, ok = token.Claims["exp"].(int64); ok {
+			vexp = true
+		}
+		if nbf, ok = token.Claims["nbf"].(int64); ok {
+			vnbf = true
 		}
 	}
-	if nbf, ok := token.Claims["nbf"].(float64); ok {
-		if now < int64(nbf) {
-			vErr.err = "token is not valid yet"
-			vErr.Errors |= ValidationErrorNotValidYet
-		}
+
+	if vexp && now > exp {
+		vErr.err = "token is expired"
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if vnbf && now < nbf {
+		vErr.err = "token is not valid yet"
+		vErr.Errors |= ValidationErrorNotValidYet
 	}
 
 	// Perform validation

--- a/parser.go
+++ b/parser.go
@@ -102,12 +102,13 @@ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 			}
 		}
 	} else {
-		var ok bool
-		if exp, ok = token.Claims["exp"].(int64); ok {
+		if num, ok := token.Claims["exp"].(float64); ok {
 			vexp = true
+			exp = int64(num)
 		}
-		if nbf, ok = token.Claims["nbf"].(int64); ok {
+		if num, ok := token.Claims["nbf"].(float64); ok {
 			vnbf = true
+			nbf = int64(num)
 		}
 	}
 


### PR DESCRIPTION
if `parser.UseJSONNumber` is true then the `Claims[“exp”]` and
`Claims[“nbf”]` can be full int64 range by using `json.Number.Int64()`, not limited to float64

passed verification test