### PR TITLE
Parser flag to skip claims validation during token parsing

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Parser struct {
-	ValidMethods  []string // If populated, only these methods will be considered valid
-	UseJSONNumber bool     // Use JSON Number format in JSON decoder
+	ValidMethods         []string // If populated, only these methods will be considered valid
+	UseJSONNumber        bool     // Use JSON Number format in JSON decoder
+	SkipClaimsValidation bool     // Skip claims validation during token parsing
 }
 
 // Parse, validate, and return a token.
@@ -101,14 +102,16 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 	vErr := &ValidationError{}
 
 	// Validate Claims
-	if err := token.Claims.Valid(); err != nil {
+	if !p.SkipClaimsValidation {
+		if err := token.Claims.Valid(); err != nil {
 
-		// If the Claims Valid returned an error, check if it is a validation error,
-		// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
-		if e, ok := err.(*ValidationError); !ok {
-			vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
-		} else {
-			vErr = e
+			// If the Claims Valid returned an error, check if it is a validation error,
+			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+			if e, ok := err.(*ValidationError); !ok {
+				vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
+			} else {
+				vErr = e
+			}
 		}
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -172,6 +172,15 @@ var jwtTestData = []struct {
 		jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired,
 		&jwt.Parser{UseJSONNumber: true},
 	},
+	{
+		"SkipClaimsValidation during token parsing",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
+		true,
+		0,
+		&jwt.Parser{UseJSONNumber: true, SkipClaimsValidation: true},
+	},
 }
 
 func TestParser_Parse(t *testing.T) {


### PR DESCRIPTION
This PR introduces a `SkipClaimsValidation` flag (default:false) to the `Parser` struct, when set will skip the claims validation when Parse() is called. The use-case is for libraries that plan to handle token verification and claims validation as independent calls.
