### PR TITLE
Fixed migration guide request.ParseFromRequest example code

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -56,8 +56,9 @@ This simple parsing example:
 is directly mapped to:
 
 ```go
-	if token, err := request.ParseFromRequest(tokenString, request.OAuth2Extractor, req, keyLookupFunc); err == nil {
-		fmt.Printf("Token for user %v expires %v", token.Claims["user"], token.Claims["exp"])
+	if token, err := request.ParseFromRequest(req, request.OAuth2Extractor, keyLookupFunc); err == nil {
+		claims := token.Claims.(jwt.MapClaims)
+		fmt.Printf("Token for user %v expires %v", claims["user"], claims["exp"])
 	}
 ```
 


### PR DESCRIPTION
Seems to be a small copy/paste error with the function arguments and Claims.