### PR TITLE
Change error message casing

### DIFF
--- a/ecdsa_utils.go
+++ b/ecdsa_utils.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	ErrNotECPublicKey  = errors.New("Key is not a valid ECDSA public key")
-	ErrNotECPrivateKey = errors.New("Key is not a valid ECDSA private key")
+	ErrNotECPublicKey  = errors.New("key is not a valid ECDSA public key")
+	ErrNotECPrivateKey = errors.New("key is not a valid ECDSA private key")
 )
 
 // Parse PEM encoded Elliptic Curve Private Key Structure

--- a/map_claims.go
+++ b/map_claims.go
@@ -72,17 +72,17 @@ func (m MapClaims) Valid() error {
 	now := TimeFunc().Unix()
 
 	if m.VerifyExpiresAt(now, false) == false {
-		vErr.Inner = errors.New("Token is expired")
+		vErr.Inner = errors.New("token is expired")
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if m.VerifyIssuedAt(now, false) == false {
-		vErr.Inner = errors.New("Token used before issued")
+		vErr.Inner = errors.New("token used before issued")
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if m.VerifyNotBefore(now, false) == false {
-		vErr.Inner = errors.New("Token is not valid yet")
+		vErr.Inner = errors.New("token is not valid yet")
 		vErr.Errors |= ValidationErrorNotValidYet
 	}
 

--- a/rsa_utils.go
+++ b/rsa_utils.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	ErrKeyMustBePEMEncoded = errors.New("Invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key")
-	ErrNotRSAPrivateKey    = errors.New("Key is not a valid RSA private key")
-	ErrNotRSAPublicKey     = errors.New("Key is not a valid RSA public key")
+	ErrKeyMustBePEMEncoded = errors.New("invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key")
+	ErrNotRSAPrivateKey    = errors.New("key is not a valid RSA private key")
+	ErrNotRSAPublicKey     = errors.New("key is not a valid RSA public key")
 )
 
 // Parse PEM encoded PKCS1 or PKCS8 private key


### PR DESCRIPTION
When updating to v3, one of our unit tests broke. Looking into it, I see at some point error messages were capitalised.

Error messages should not be capitalised unless they're acronyms or proper nouns, so that they can be composed with other text when, for example, logging them.

See [here](https://github.com/golang/go/wiki/CodeReviewComments#error-strings) for more details.

