### PR TITLE
Allow bypassing iat verification

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -25,6 +25,12 @@ type StandardClaims struct {
 	Subject   string `json:"sub,omitempty"`
 }
 
+var ClaimVerificationOptions = struct {
+	VerifyIssuedAt bool
+}{
+	VerifyIssuedAt: true,
+}
+
 // Validates time based claims "exp, iat, nbf".
 // There is no accounting for clock skew.
 // As well, if any of the above claims are not in the token, it will still
@@ -41,9 +47,11 @@ func (c StandardClaims) Valid() error {
 		vErr.Errors |= ValidationErrorExpired
 	}
 
-	if c.VerifyIssuedAt(now, false) == false {
-		vErr.Inner = fmt.Errorf("Token used before issued")
-		vErr.Errors |= ValidationErrorIssuedAt
+	if ClaimVerificationOptions.VerifyIssuedAt {
+		if c.VerifyIssuedAt(now, false) == false {
+			vErr.Inner = fmt.Errorf("Token used before issued")
+			vErr.Errors |= ValidationErrorIssuedAt
+		}
 	}
 
 	if c.VerifyNotBefore(now, false) == false {

--- a/claims.go
+++ b/claims.go
@@ -47,11 +47,9 @@ func (c StandardClaims) Valid() error {
 		vErr.Errors |= ValidationErrorExpired
 	}
 
-	if ClaimVerificationOptions.VerifyIssuedAt {
-		if c.VerifyIssuedAt(now, false) == false {
-			vErr.Inner = fmt.Errorf("Token used before issued")
-			vErr.Errors |= ValidationErrorIssuedAt
-		}
+	if c.VerifyIssuedAt(now, false) == false {
+		vErr.Inner = fmt.Errorf("Token used before issued")
+		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if c.VerifyNotBefore(now, false) == false {
@@ -117,7 +115,9 @@ func verifyExp(exp int64, now int64, required bool) bool {
 }
 
 func verifyIat(iat int64, now int64, required bool) bool {
-	if iat == 0 {
+	if ClaimVerificationOptions.VerifyIssuedAt == false {
+		return true
+	} else if iat == 0 {
 		return !required
 	}
 	return now >= iat


### PR DESCRIPTION
Our team is having issues with using this library due to clock skew, so we would like to have the ability to disable iat verification.

We are aware of pull request #139. Rather than allowing leeway, this change allows the bypassing of iat verification entirely (and could be expanded to the bypassing of additional verification). In contrast to #139, we have used a global singleton, with no breaking changes to the interface. This concept could be expanded to include leeway, but that was outside of the intended scope of this pull request.