### PR TITLE
Remove unreachable code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: go
 
+script:
+    - go vet ./...
+    - go test -v ./...
+
 go:
   - 1.3
   - 1.4
   - 1.5
   - 1.6
+  - 1.7
   - tip

--- a/errors.go
+++ b/errors.go
@@ -51,13 +51,9 @@ func (e ValidationError) Error() string {
 	} else {
 		return "token is invalid"
 	}
-	return e.Inner.Error()
 }
 
 // No errors
 func (e *ValidationError) valid() bool {
-	if e.Errors > 0 {
-		return false
-	}
-	return true
+	return e.Errors == 0
 }


### PR DESCRIPTION
`go vet` on Go 1.8 errors because this line of code is unreachable. Adds
a check that new code passes go vet, and adds Go 1.7 to travisci.