### PR TITLE
Clarify hmacSampleSecret type

### DIFF
--- a/hmac_example_test.go
+++ b/hmac_example_test.go
@@ -51,6 +51,8 @@ func ExampleParse_hmac() {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}
+		
+		// hmacSampleSecret is a []byte containing your secret, e.g. []byte("my_secret_key")
 		return hmacSampleSecret, nil
 	})
 


### PR DESCRIPTION
From looking at the godoc for this (https://godoc.org/github.com/dgrijalva/jwt-go#example-Parse--Hmac) it isn't clear what the type of hmacSampleSecret should be as you can't see the rest of this file. I ended up having to search through the code to figure out it needed to be a byte array.