### PR TITLE
add additional header options to the command line tool

### DIFF
--- a/cmd/jwt/app.go
+++ b/cmd/jwt/app.go
@@ -21,11 +21,12 @@ import (
 
 var (
 	// Options
-	flagAlg     = flag.String("alg", "", "signing algorithm identifier")
-	flagKey     = flag.String("key", "", "path to key file or '-' to read from stdin")
-	flagCompact = flag.Bool("compact", false, "output compact JSON")
-	flagDebug   = flag.Bool("debug", false, "print out all kinds of debug data")
-	flagKid     = flag.String("kid", "", "key id to use")
+	flagAlg        = flag.String("alg", "", "signing algorithm identifier")
+	flagKey        = flag.String("key", "", "path to key file or '-' to read from stdin")
+	flagCompact    = flag.Bool("compact", false, "output compact JSON")
+	flagDebug      = flag.Bool("debug", false, "print out all kinds of debug data")
+	flagKid        = flag.String("kid", "", "key id to use")
+	flagConentType = flag.String("cty", "", "content type to set")
 
 	// Modes - exactly one of these is required
 	flagSign   = flag.String("sign", "", "path to claims object to sign or '-' to read from stdin")
@@ -188,12 +189,18 @@ func signToken() error {
 	// create a new token
 	token := jwt.NewWithClaims(alg, claims)
 
+	// add the algorithm header
+	token.Header["alg"] = *flagAlg
+
+	// if we were given a kid add the header
 	if *flagKid != "" {
 		token.Header["kid"] = *flagKid
 	}
 
-	// add the algorithm header
-	token.Header["alg"] = *flagAlg
+	// if we were given a content type, add it
+	if *flagConentType != "" {
+		token.Header["cty"] = *flagConentType
+	}
 
 	if isEs() {
 		if k, ok := key.([]byte); !ok {

--- a/cmd/jwt/app.go
+++ b/cmd/jwt/app.go
@@ -25,6 +25,7 @@ var (
 	flagKey     = flag.String("key", "", "path to key file or '-' to read from stdin")
 	flagCompact = flag.Bool("compact", false, "output compact JSON")
 	flagDebug   = flag.Bool("debug", false, "print out all kinds of debug data")
+	flagKid     = flag.String("kid", "", "key id to use")
 
 	// Modes - exactly one of these is required
 	flagSign   = flag.String("sign", "", "path to claims object to sign or '-' to read from stdin")
@@ -186,6 +187,10 @@ func signToken() error {
 
 	// create a new token
 	token := jwt.NewWithClaims(alg, claims)
+
+	if *flagKid != "" {
+		token.Header["kid"] = *flagKid
+	}
 
 	if isEs() {
 		if k, ok := key.([]byte); !ok {

--- a/cmd/jwt/app.go
+++ b/cmd/jwt/app.go
@@ -192,6 +192,9 @@ func signToken() error {
 		token.Header["kid"] = *flagKid
 	}
 
+	// add the algorithm header
+	token.Header["alg"] = *flagAlg
+
 	if isEs() {
 		if k, ok := key.([]byte); !ok {
 			return fmt.Errorf("Couldn't convert key data to key")


### PR DESCRIPTION
I had a need to set the key and algorithm headers so I added support for them..

While I was in there I set the algorithm since we already know it.  I debated about adding an option to include it, but figured it's not that much more data to include it.

I also added support for setting the content type, which might be overkill, but it was easy to add.