### PR TITLE
Add custom marshaler and unmarshaler to parser and token

### DIFF
--- a/token.go
+++ b/token.go
@@ -18,15 +18,19 @@ var TimeFunc = time.Now
 // Header of the token (such as `kid`) to identify which key to use.
 type Keyfunc func(*Token) (interface{}, error)
 
+// The custom marshaler to marshal claims to bytes
+type Marshaler func(interface{}) ([]byte, error)
+
 // A JWT Token.  Different fields will be used depending on whether you're
 // creating or parsing/verifying a token.
 type Token struct {
-	Raw       string                 // The raw token.  Populated when you Parse a token
-	Method    SigningMethod          // The signing method used or to be used
-	Header    map[string]interface{} // The first segment of the token
-	Claims    Claims                 // The second segment of the token
-	Signature string                 // The third segment of the token.  Populated when you Parse a token
-	Valid     bool                   // Is the token valid?  Populated when you Parse/Verify a token
+	Raw            string                 // The raw token.  Populated when you Parse a token
+	Method         SigningMethod          // The signing method used or to be used
+	Header         map[string]interface{} // The first segment of the token
+	Claims         Claims                 // The second segment of the token
+	Signature      string                 // The third segment of the token.  Populated when you Parse a token
+	Valid          bool                   // Is the token valid?  Populated when you Parse/Verify a token
+	ClaimMarshaler Marshaler              // The custom marshaler
 }
 
 // Create a new Token.  Takes a signing method
@@ -72,8 +76,16 @@ func (t *Token) SigningString() (string, error) {
 				return "", err
 			}
 		} else {
-			if jsonValue, err = json.Marshal(t.Claims); err != nil {
-				return "", err
+			if t.ClaimMarshaler == nil {
+				// Use standard json marshaler
+				if jsonValue, err = json.Marshal(t.Claims); err != nil {
+					return "", err
+				}
+			} else {
+				// Use custom marshaler
+				if jsonValue, err = t.ClaimMarshaler(t.Claims); err != nil {
+					return "", err
+				}
 			}
 		}
 


### PR DESCRIPTION
hi,

I have added custom marshaler / unmarshaler to parser and token in order to make it more flexible.

My use case: I'm using protobuf generated data type as the `claims` and protobuf object requires protobuf json encoder / decoder to handle their special cases. (Such as timestamp etc..). So in this pr, I can set the newly added ClaimMarshaler & ClaimUnmarshaler to a custom function to correctly encode / decode object.

I think it may be a general use case, please take a look.