### PR TITLE
Fix base64 token decoding

### DIFF
--- a/token.go
+++ b/token.go
@@ -104,5 +104,5 @@ func DecodeSegment(seg string) ([]byte, error) {
 		seg += strings.Repeat("=", 4-l)
 	}
 
-	return base64.URLEncoding.DecodeString(seg)
+	return base64.StdEncoding.DecodeString(seg)
 }

--- a/token_test.go
+++ b/token_test.go
@@ -1,13 +1,12 @@
-package jwt_test
+package jwt
 
 import (
 	"testing"
-	"github.com/dgrijalva/jwt-go"
 )
 
 func TestDecodeSegment(t *testing.T) {
 	validSegment := "nxEWX7UD76fRupczm4MWL0B4UQh/tGpjSdWi6z/wlkw="
-	_, err := jwt.DecodeSegment(validSegment)
+	_, err := DecodeSegment(validSegment)
 	if err != nil {
 		t.Errorf("Unable to decode segment %s", validSegment)
 	}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,15 @@
+package jwt_test
+
+import (
+	"testing"
+	"github.com/dgrijalva/jwt-go"
+)
+
+func TestDecodeSegment(t *testing.T) {
+	validSegment := "nxEWX7UD76fRupczm4MWL0B4UQh/tGpjSdWi6z/wlkw="
+	_, err := jwt.DecodeSegment(validSegment)
+	if err != nil {
+		t.Errorf("Unable to decode segment %s", validSegment)
+	}
+}
+


### PR DESCRIPTION
When decoding token segments using base64, the URLDecoder does not support the = character