### PR TITLE
Implement options and compression for JWTs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -48,6 +48,16 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 	if claimBytes, err = DecodeSegment(parts[1]); err != nil {
 		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
 	}
+
+	if compression, ok := token.Header["zip"].(string); ok {
+		if err = validateCompressionAlgorithm(compression); err != nil {
+			return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		}
+		claimBytes, err = decompress(claimBytes)
+		if err != nil {
+			return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		}
+	}
 	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
 	if p.UseJSONNumber {
 		dec.UseNumber()

--- a/parser_test.go
+++ b/parser_test.go
@@ -27,17 +27,19 @@ func init() {
 }
 
 var jwtTestData = []struct {
-	name        string
-	tokenString string
-	keyfunc     jwt.Keyfunc
-	claims      jwt.Claims
-	valid       bool
-	errors      uint32
-	parser      *jwt.Parser
+	name         string
+	tokenString  string
+	tokenOptions []jwt.TokenOption
+	keyfunc      jwt.Keyfunc
+	claims       jwt.Claims
+	valid        bool
+	errors       uint32
+	parser       *jwt.Parser
 }{
 	{
 		"basic",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		true,
@@ -47,6 +49,7 @@ var jwtTestData = []struct {
 	{
 		"basic expired",
 		"", // autogen
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
 		false,
@@ -56,6 +59,7 @@ var jwtTestData = []struct {
 	{
 		"basic nbf",
 		"", // autogen
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
 		false,
@@ -65,6 +69,7 @@ var jwtTestData = []struct {
 	{
 		"expired and nbf",
 		"", // autogen
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100), "exp": float64(time.Now().Unix() - 100)},
 		false,
@@ -74,6 +79,7 @@ var jwtTestData = []struct {
 	{
 		"basic invalid",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.EhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -83,6 +89,7 @@ var jwtTestData = []struct {
 	{
 		"basic nokeyfunc",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		nil,
 		nilKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -92,6 +99,7 @@ var jwtTestData = []struct {
 	{
 		"basic nokey",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		nil,
 		emptyKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -101,6 +109,7 @@ var jwtTestData = []struct {
 	{
 		"basic errorkey",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		nil,
 		errorKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -110,6 +119,7 @@ var jwtTestData = []struct {
 	{
 		"invalid signing method",
 		"",
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		false,
@@ -119,6 +129,7 @@ var jwtTestData = []struct {
 	{
 		"valid signing method",
 		"",
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar"},
 		true,
@@ -128,6 +139,7 @@ var jwtTestData = []struct {
 	{
 		"JSON Number",
 		"",
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": json.Number("123.4")},
 		true,
@@ -137,6 +149,7 @@ var jwtTestData = []struct {
 	{
 		"Standard Claims",
 		"",
+		nil,
 		defaultKeyFunc,
 		&jwt.StandardClaims{
 			ExpiresAt: time.Now().Add(time.Second * 10).Unix(),
@@ -148,6 +161,7 @@ var jwtTestData = []struct {
 	{
 		"JSON Number - basic expired",
 		"", // autogen
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
 		false,
@@ -157,6 +171,7 @@ var jwtTestData = []struct {
 	{
 		"JSON Number - basic nbf",
 		"", // autogen
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
 		false,
@@ -166,6 +181,7 @@ var jwtTestData = []struct {
 	{
 		"JSON Number - expired and nbf",
 		"", // autogen
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100)), "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
 		false,
@@ -175,11 +191,42 @@ var jwtTestData = []struct {
 	{
 		"SkipClaimsValidation during token parsing",
 		"", // autogen
+		nil,
 		defaultKeyFunc,
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
 		true,
 		0,
 		&jwt.Parser{UseJSONNumber: true, SkipClaimsValidation: true},
+	},
+	{
+		"basic compress",
+		"", // autogen
+		[]jwt.TokenOption{jwt.WithCompression()},
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar"},
+		true,
+		0,
+		nil,
+	},
+	{
+		"basic decompress",
+		"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkRFRiJ9.H4sIAAAAAAAA_6pWSsvPV7JSSkosUqoFAAAA__8BAAD__-_1K_4NAAAA.pK5ZCz_R70mg_HfmRR2OzgXE6US4FYJY8aRFqCmFUG_6DgAEjQdhPRP4uBDueW3YIwBVGZ8p5oVytuVRvkgx9oso3f6T1aaMhAyfIMrc7h4EhCy6xUPec69j5H6054wel1MYEQwwKqyIuBag2a60Djaaiz430EbiJHQ5nS3vKK8sOcKkLlv2aFKfxipcBc4LEZSDXYQgFV0GJeT-_6oeCoH6FBPgUt_OXf-CGC1EApaY81-j3ich9nYlLwfp5T4ArCd07jTawhXFgSY1K36L4LZL2mZegxPeLVJ1yacRO1uF4hBufurBSbW25FpS4UVl8uOwBTT09Ce3ihcQM37ZRA",
+		nil,
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar"},
+		true,
+		0,
+		nil,
+	},
+	{
+		"invalid compression algorithm",
+		"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsInppcCI6Ik9UUiJ9.H4sIAAAAAAAA_6pWSsvPV7JSSkosUqoFAAAA__8BAAD__-_1K_4NAAAA.pK5ZCz_R70mg_HfmRR2OzgXE6US4FYJY8aRFqCmFUG_6DgAEjQdhPRP4uBDueW3YIwBVGZ8p5oVytuVRvkgx9oso3f6T1aaMhAyfIMrc7h4EhCy6xUPec69j5H6054wel1MYEQwwKqyIuBag2a60Djaaiz430EbiJHQ5nS3vKK8sOcKkLlv2aFKfxipcBc4LEZSDXYQgFV0GJeT-_6oeCoH6FBPgUt_OXf-CGC1EApaY81-j3ich9nYlLwfp5T4ArCd07jTawhXFgSY1K36L4LZL2mZegxPeLVJ1yacRO1uF4hBufurBSbW25FpS4UVl8uOwBTT09Ce3ihcQM37ZRA",
+		nil,
+		defaultKeyFunc,
+		jwt.MapClaims{},
+		false,
+		jwt.ValidationErrorMalformed,
+		nil,
 	},
 }
 
@@ -190,7 +237,7 @@ func TestParser_Parse(t *testing.T) {
 	for _, data := range jwtTestData {
 		// If the token string is blank, use helper function to generate string
 		if data.tokenString == "" {
-			data.tokenString = test.MakeSampleToken(data.claims, privateKey)
+			data.tokenString = test.MakeSampleToken(data.tokenOptions, data.claims, privateKey)
 		}
 
 		// Parse the token

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -2,13 +2,14 @@ package request
 
 import (
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/dgrijalva/jwt-go/test"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go/test"
 )
 
 var requestTestData = []struct {
@@ -64,7 +65,7 @@ func TestParseRequest(t *testing.T) {
 	// Bearer token request
 	for _, data := range requestTestData {
 		// Make token from claims
-		tokenString := test.MakeSampleToken(data.claims, privateKey)
+		tokenString := test.MakeSampleToken(nil, data.claims, privateKey)
 
 		// Make query string
 		for k, vv := range data.query {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"crypto/rsa"
-	"github.com/dgrijalva/jwt-go"
 	"io/ioutil"
+
+	"github.com/dgrijalva/jwt-go"
 )
 
 func LoadRSAPrivateKeyFromDisk(location string) *rsa.PrivateKey {
@@ -30,10 +31,15 @@ func LoadRSAPublicKeyFromDisk(location string) *rsa.PublicKey {
 	return key
 }
 
-func MakeSampleToken(c jwt.Claims, key interface{}) string {
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, c)
-	s, e := token.SignedString(key)
+func MakeSampleToken(o []jwt.TokenOption, c jwt.Claims, key interface{}) string {
+	o = append(o, jwt.WithSigningMethod(jwt.SigningMethodRS256))
+	o = append(o, jwt.WithClaims(c))
+	token, e := jwt.NewWithOptions(o...)
+	if e != nil {
+		panic(e.Error())
+	}
 
+	s, e := token.SignedString(key)
 	if e != nil {
 		panic(e.Error())
 	}


### PR DESCRIPTION
This provides a new entrypoint, `NewWithOptions`, that takes variadic `TokenOption`s, which are provided by [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis). Those functional options include `WithSigningMethod`, `WithClaims`, and `WithCompression`. 

`New` and `NewWithClaims` have been refactored to use `NewWithOptions` under the hood.

`WithCompression` sets the appropriate header value [specified in the RFC](https://tools.ietf.org/html/rfc7516#page-12) and compresses the JSON body with gzip (deflate). This fixes #227.

This is not a breaking change. All Unit tests pass. I still need to update the documentation with some examples.