### PR TITLE
Make error message case consistent

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -82,7 +82,7 @@ To replace this behavior, we've added two helper methods: `ParseRSAPrivateKeyFro
 	func keyLookupFunc(*Token) (interface{}, error) {
 		// Don't forget to validate the alg is what you expect:
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		
 		// Look up key 

--- a/claims.go
+++ b/claims.go
@@ -42,7 +42,7 @@ func (c StandardClaims) Valid() error {
 	}
 
 	if c.VerifyIssuedAt(now, false) == false {
-		vErr.Inner = fmt.Errorf("Token used before issued")
+		vErr.Inner = fmt.Errorf("token used before issued")
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 

--- a/cmd/jwt/app.go
+++ b/cmd/jwt/app.go
@@ -67,14 +67,14 @@ func start() error {
 		return showToken()
 	} else {
 		flag.Usage()
-		return fmt.Errorf("None of the required flags are present.  What do you want me to do?")
+		return fmt.Errorf("none of the required flags are present.  What do you want me to do?")
 	}
 }
 
 // Helper func:  Read input from specified file or stdin
 func loadData(p string) ([]byte, error) {
 	if p == "" {
-		return nil, fmt.Errorf("No path specified")
+		return nil, fmt.Errorf("no path specified")
 	}
 
 	var rdr io.Reader
@@ -117,7 +117,7 @@ func verifyToken() error {
 	// get the token
 	tokData, err := loadData(*flagVerify)
 	if err != nil {
-		return fmt.Errorf("Couldn't read token: %v", err)
+		return fmt.Errorf("couldn't read token: %v", err)
 	}
 
 	// trim possible whitespace from token
@@ -148,17 +148,17 @@ func verifyToken() error {
 
 	// Print an error if we can't parse for some reason
 	if err != nil {
-		return fmt.Errorf("Couldn't parse token: %v", err)
+		return fmt.Errorf("couldn't parse token: %v", err)
 	}
 
 	// Is token invalid?
 	if !token.Valid {
-		return fmt.Errorf("Token is invalid")
+		return fmt.Errorf("token is invalid")
 	}
 
 	// Print the token details
 	if err := printJSON(token.Claims); err != nil {
-		return fmt.Errorf("Failed to output claims: %v", err)
+		return fmt.Errorf("failed to output claims: %v", err)
 	}
 
 	return nil
@@ -170,7 +170,7 @@ func signToken() error {
 	// get the token data from command line arguments
 	tokData, err := loadData(*flagSign)
 	if err != nil {
-		return fmt.Errorf("Couldn't read token: %v", err)
+		return fmt.Errorf("couldn't read token: %v", err)
 	} else if *flagDebug {
 		fmt.Fprintf(os.Stderr, "Token: %v bytes", len(tokData))
 	}
@@ -178,7 +178,7 @@ func signToken() error {
 	// parse the JSON of the claims
 	var claims jwt.MapClaims
 	if err := json.Unmarshal(tokData, &claims); err != nil {
-		return fmt.Errorf("Couldn't parse claims JSON: %v", err)
+		return fmt.Errorf("couldn't parse claims JSON: %v", err)
 	}
 
 	// add command line claims
@@ -192,13 +192,13 @@ func signToken() error {
 	var key interface{}
 	key, err = loadData(*flagKey)
 	if err != nil {
-		return fmt.Errorf("Couldn't read key: %v", err)
+		return fmt.Errorf("couldn't read key: %v", err)
 	}
 
 	// get the signing alg
 	alg := jwt.GetSigningMethod(*flagAlg)
 	if alg == nil {
-		return fmt.Errorf("Couldn't find signing method: %v", *flagAlg)
+		return fmt.Errorf("couldn't find signing method: %v", *flagAlg)
 	}
 
 	// create a new token
@@ -213,7 +213,7 @@ func signToken() error {
 
 	if isEs() {
 		if k, ok := key.([]byte); !ok {
-			return fmt.Errorf("Couldn't convert key data to key")
+			return fmt.Errorf("couldn't convert key data to key")
 		} else {
 			key, err = jwt.ParseECPrivateKeyFromPEM(k)
 			if err != nil {
@@ -222,7 +222,7 @@ func signToken() error {
 		}
 	} else if isRs() {
 		if k, ok := key.([]byte); !ok {
-			return fmt.Errorf("Couldn't convert key data to key")
+			return fmt.Errorf("couldn't convert key data to key")
 		} else {
 			key, err = jwt.ParseRSAPrivateKeyFromPEM(k)
 			if err != nil {
@@ -234,7 +234,7 @@ func signToken() error {
 	if out, err := token.SignedString(key); err == nil {
 		fmt.Println(out)
 	} else {
-		return fmt.Errorf("Error signing token: %v", err)
+		return fmt.Errorf("error signing token: %v", err)
 	}
 
 	return nil
@@ -245,7 +245,7 @@ func showToken() error {
 	// get the token
 	tokData, err := loadData(*flagShow)
 	if err != nil {
-		return fmt.Errorf("Couldn't read token: %v", err)
+		return fmt.Errorf("couldn't read token: %v", err)
 	}
 
 	// trim possible whitespace from token
@@ -262,12 +262,12 @@ func showToken() error {
 	// Print the token details
 	fmt.Println("Header:")
 	if err := printJSON(token.Header); err != nil {
-		return fmt.Errorf("Failed to output header: %v", err)
+		return fmt.Errorf("failed to output header: %v", err)
 	}
 
 	fmt.Println("Claims:")
 	if err := printJSON(token.Claims); err != nil {
-		return fmt.Errorf("Failed to output claims: %v", err)
+		return fmt.Errorf("failed to output claims: %v", err)
 	}
 
 	return nil

--- a/cmd/jwt/args.go
+++ b/cmd/jwt/args.go
@@ -16,7 +16,7 @@ func (l ArgList) String() string {
 func (l ArgList) Set(arg string) error {
 	parts := strings.SplitN(arg, "=", 2)
 	if len(parts) != 2 {
-		return fmt.Errorf("Invalid argument '%v'.  Must use format 'key=value'. %v", arg, parts)
+		return fmt.Errorf("invalid argument '%v'. Must use format 'key=value'. %v", arg, parts)
 	}
 	l[parts[0]] = parts[1]
 	return nil

--- a/ecdsa_utils.go
+++ b/ecdsa_utils.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	ErrNotECPublicKey  = errors.New("Key is not a valid ECDSA public key")
-	ErrNotECPrivateKey = errors.New("Key is not a valid ECDSA private key")
+	ErrNotECPublicKey  = errors.New("key is not a valid ECDSA public key")
+	ErrNotECPrivateKey = errors.New("key is not a valid ECDSA private key")
 )
 
 // Parse PEM encoded Elliptic Curve Private Key Structure

--- a/hmac_example_test.go
+++ b/hmac_example_test.go
@@ -2,9 +2,10 @@ package jwt_test
 
 import (
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
 	"io/ioutil"
 	"time"
+
+	"github.com/dgrijalva/jwt-go"
 )
 
 // For HMAC signing method, the key can be any []byte. It is recommended to generate
@@ -49,9 +50,9 @@ func ExampleParse_hmac() {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		// Don't forget to validate the alg is what you expect:
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
-		
+
 		// hmacSampleSecret is a []byte containing your secret, e.g. []byte("my_secret_key")
 		return hmacSampleSecret, nil
 	})

--- a/map_claims.go
+++ b/map_claims.go
@@ -72,17 +72,17 @@ func (m MapClaims) Valid() error {
 	now := TimeFunc().Unix()
 
 	if m.VerifyExpiresAt(now, false) == false {
-		vErr.Inner = errors.New("Token is expired")
+		vErr.Inner = errors.New("token is expired")
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if m.VerifyIssuedAt(now, false) == false {
-		vErr.Inner = errors.New("Token used before issued")
+		vErr.Inner = errors.New("token used before issued")
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if m.VerifyNotBefore(now, false) == false {
-		vErr.Inner = errors.New("Token is not valid yet")
+		vErr.Inner = errors.New("token is not valid yet")
 		vErr.Errors |= ValidationErrorNotValidYet
 	}
 

--- a/rsa_utils.go
+++ b/rsa_utils.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	ErrKeyMustBePEMEncoded = errors.New("Invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key")
-	ErrNotRSAPrivateKey    = errors.New("Key is not a valid RSA private key")
-	ErrNotRSAPublicKey     = errors.New("Key is not a valid RSA public key")
+	ErrKeyMustBePEMEncoded = errors.New("invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key")
+	ErrNotRSAPrivateKey    = errors.New("key is not a valid RSA private key")
+	ErrNotRSAPublicKey     = errors.New("key is not a valid RSA public key")
 )
 
 // Parse PEM encoded PKCS1 or PKCS8 private key


### PR DESCRIPTION
I noticed that almost all error messages began with a capital letter—and I realise this is a _very trivial_ change (so, feel free to close)—so I thought I'd spend the minute to make the changes. 😅