### PR TITLE
typo fix

### DIFF
--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -32,7 +32,8 @@
 
 #### 2.7.0
 
-This will likely be the last backwards compatible release before 3.0.0, excluding essential bug fixes.
+This will likely be the last backwards 
+ble release before 3.0.0, excluding essential bug fixes.
 
 * Added new option `-show` to the `jwt` command that will just output the decoded token without verifying
 * Error text for expired tokens includes how long it's been expired
@@ -78,7 +79,7 @@ Backwards compatible API change that was missed in 2.0.0.
 
 There were two major reasons for breaking backwards compatibility with this update.  The first was a refactor required to expand the width of the RSA and HMAC-SHA signing implementations.  There will likely be no required code changes to support this change.
 
-The second update, while unfortunately requiring a small change in integration, is required to open up this library to other signing methods.  Not all keys used for all signing methods have a single standard on-disk representation.  Requiring `[]byte` as the type for all keys proved too limiting.  Additionally, this implementation allows for pre-parsed tokens to be reused, which might matter in an application that parses a high volume of tokens with a small set of keys.  Backwards compatibilty has been maintained for passing `[]byte` to the RSA signing methods, but they will also accept `*rsa.PublicKey` and `*rsa.PrivateKey`.
+The second update, while unfortunately requiring a small change in integration, is required to open up this library to other signing methods.  Not all keys used for all signing methods have a single standard on-disk representation.  Requiring `[]byte` as the type for all keys proved too limiting.  Additionally, this implementation allows for pre-parsed tokens to be reused, which might matter in an application that parses a high volume of tokens with a small set of keys.  Backwards compatibility has been maintained for passing `[]byte` to the RSA signing methods, but they will also accept `*rsa.PublicKey` and `*rsa.PrivateKey`.
 
 It is likely the only integration change required here will be to change `func(t *jwt.Token) ([]byte, error)` to `func(t *jwt.Token) (interface{}, error)` when calling `Parse`.
 


### PR DESCRIPTION
"compatibilty" is a misspelling of "compatibility"