### PR TITLE
Make compatible with go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module "github.com/dgrijalva/jwt-go"
+module github.com/dgrijalva/jwt-go/v3

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module "github.com/dgrijalva/jwt-go"


### PR DESCRIPTION
As stated in golang/go#24384:

> vgo only allows v2+ when there is a go.mod file so please tell the package maintainer/owner to make the package vgo compatible.

Thus it's impossible to add anything after version 1.0.2 of this package as dependency in project built with vgo. 