### PR TITLE
Added support for array values for the aud field

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -16,13 +16,13 @@ type Claims interface {
 // https://tools.ietf.org/html/rfc7519#section-4.1
 // See examples for how to use this with your own claim types
 type StandardClaims struct {
-	Audience  string `json:"aud,omitempty"`
-	ExpiresAt int64  `json:"exp,omitempty"`
-	Id        string `json:"jti,omitempty"`
-	IssuedAt  int64  `json:"iat,omitempty"`
-	Issuer    string `json:"iss,omitempty"`
-	NotBefore int64  `json:"nbf,omitempty"`
-	Subject   string `json:"sub,omitempty"`
+	Audience  interface{} `json:"aud,omitempty"`
+	ExpiresAt int64       `json:"exp,omitempty"`
+	Id        string      `json:"jti,omitempty"`
+	IssuedAt  int64       `json:"iat,omitempty"`
+	Issuer    string      `json:"iss,omitempty"`
+	NotBefore int64       `json:"nbf,omitempty"`
+	Subject   string      `json:"sub,omitempty"`
 }
 
 // Validates time based claims "exp, iat, nbf".
@@ -58,10 +58,28 @@ func (c StandardClaims) Valid() error {
 	return vErr
 }
 
+// Extracts an array of audience values from the aud field.
+func ExtractAudience(c *StandardClaims) []string {
+	switch c.Audience.(type) {
+	case []interface{}:
+		auds := make([]string, len(c.Audience.([]interface{})))
+		for i, value := range c.Audience.([]interface{}) {
+			auds[i] = value.(string)
+		}
+		return auds
+	case []string:
+		return c.Audience.([]string)
+	default:
+		return []string{c.Audience.(string)}
+	}
+}
+
 // Compares the aud claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
-	return verifyAud(c.Audience, cmp, req)
+	audiences := ExtractAudience(c)
+
+	return verifyAud(audiences, cmp, req)
 }
 
 // Compares the exp claim against cmp.
@@ -90,13 +108,15 @@ func (c *StandardClaims) VerifyNotBefore(cmp int64, req bool) bool {
 
 // ----- helpers
 
-func verifyAud(aud string, cmp string, required bool) bool {
-	if aud == "" {
+func verifyAud(auds []string, cmp string, required bool) bool {
+	if len(auds) == 0 {
 		return !required
-	}
-	if subtle.ConstantTimeCompare([]byte(aud), []byte(cmp)) != 0 {
-		return true
 	} else {
+		for _, aud := range auds {
+			if subtle.ConstantTimeCompare([]byte(aud), []byte(cmp)) != 0 {
+				return true
+			}
+		}
 		return false
 	}
 }

--- a/claims.go
+++ b/claims.go
@@ -78,7 +78,6 @@ func ExtractAudience(c *StandardClaims) []string {
 // If required is false, this method will return true if the value matches or is unset
 func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
 	audiences := ExtractAudience(c)
-
 	return verifyAud(audiences, cmp, req)
 }
 

--- a/claims_test.go
+++ b/claims_test.go
@@ -1,0 +1,102 @@
+package jwt
+
+import (
+	"testing"
+)
+
+var fixedAudienceKeyForClaims = "Aud"
+var claimWithAudience = []StandardClaims{
+	{
+		fixedAudienceKeyForClaims,
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+	{
+		[]string{fixedAudienceKeyForClaims},
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+	{
+		[]interface{}{fixedAudienceKeyForClaims},
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+}
+
+var claimWithoutAudience = []StandardClaims{
+	{
+		[]string{},
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+	{
+		[]interface{}{},
+		123123,
+		"Id",
+		12312,
+		"Issuer",
+		12312,
+		"Subject",
+	},
+}
+
+func TestExtractAudience_WithAudienceValues(t *testing.T) {
+	for _, data := range claimWithAudience {
+		var aud = ExtractAudience(&data)
+		if len(aud) == 0 || aud[0] != fixedAudienceKeyForClaims {
+			t.Errorf("The audience value was not extracted properly")
+		}
+	}
+}
+
+func TestExtractAudience_WithoutAudienceValues(t *testing.T) {
+	for _, data := range claimWithoutAudience {
+		var aud = ExtractAudience(&data)
+		if len(aud) != 0 {
+			t.Errorf("An audience value should not have been extracted")
+		}
+	}
+}
+
+var audWithValues = [][]string{
+	[]string{fixedAudienceKeyForClaims},
+	[]string{"Aud1", "Aud2", fixedAudienceKeyForClaims},
+}
+
+var audWithLackingOriginalValue = [][]string{
+	[]string{},
+	[]string{fixedAudienceKeyForClaims + "1"},
+	[]string{"Aud1", "Aud2", fixedAudienceKeyForClaims + "1"},
+}
+
+func TestVerifyAud_ShouldVerifyExists(t *testing.T) {
+	for _, data := range audWithValues {
+		if !verifyAud(data, fixedAudienceKeyForClaims, true) {
+			t.Errorf("The audience value was not verified properly")
+		}
+	}
+}
+
+func TestVerifyAud_ShouldVerifyDoesNotExist(t *testing.T) {
+	for _, data := range audWithValues {
+		if !verifyAud(data, fixedAudienceKeyForClaims, true) {
+			t.Errorf("The audience value was not verified properly")
+		}
+	}
+}

--- a/map_claims.go
+++ b/map_claims.go
@@ -13,8 +13,18 @@ type MapClaims map[string]interface{}
 // Compares the aud claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
-	aud, _ := m["aud"].(string)
-	return verifyAud(aud, cmp, req)
+	switch aud := m["aud"].(type) {
+	case []string:
+		return verifyAud(aud, cmp, req)
+	case []interface{}:
+		auds := make([]string, len(aud))
+		for i, value := range aud {
+			auds[i] = value.(string)
+		}
+		return verifyAud(auds, cmp, req)
+	default:
+		return verifyAud([]string{aud.(string)}, cmp, req)
+	}
 }
 
 // Compares the exp claim against cmp.

--- a/map_claims_tests.go
+++ b/map_claims_tests.go
@@ -1,0 +1,46 @@
+package jwt
+
+import (
+	"testing"
+)
+
+var audFixedValue = "Aud"
+var audClaimsMapsWithValues = []MapClaims{
+	{
+		"aud": audFixedValue,
+	},
+	{
+		"aud": []string{audFixedValue},
+	},
+	{
+		"aud": []interface{}{audFixedValue},
+	},
+}
+
+var audClaimsMapsWithoutValues = []MapClaims{
+	{},
+	{
+		"aud": []string{},
+	},
+	{
+		"aud": []interface{}{},
+	},
+}
+
+// Verifies that for every form of the "aud" field, the audFixedValue is always verifiable
+func TestVerifyAudienceWithVerifiableValues(t *testing.T) {
+	for _, data := range audClaimsMapsWithValues {
+		if !data.VerifyAudience(audFixedValue, true) {
+			t.Errorf("The audience value was not extracted properly")
+		}
+	}
+}
+
+// Verifies that for every empty form of the "aud" field, the audFixedValue cannot be verified
+func TestVerifyAudienceWithoutVerifiableValues(t *testing.T) {
+	for _, data := range audClaimsMapsWithoutValues {
+		if data.VerifyAudience(audFixedValue, true) {
+			t.Errorf("The audience should not verify")
+		}
+	}
+}


### PR DESCRIPTION
As per the JWT [spec](https://tools.ietf.org/html/rfc7519#section-4.1.3), the aud claim field can be either a single string value or an array of strings.

jwt-go would completely drop array values as the StandardClaims struct's Audience field is a string value and the value is dropped upon deserialization.