### PR TITLE
 cut-off timestamp after second part (10th digit)

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -90,6 +90,18 @@ func (c *StandardClaims) VerifyNotBefore(cmp int64, req bool) bool {
 
 // ----- helpers
 
+func cutOff(ts int64) int64 {
+	digit := 0
+	for i := ts; i > 0; digit++ {
+		i /= 10
+	}
+	for digit > 10 {
+		ts /= 10
+		digit--
+	}
+	return ts
+}
+
 func verifyAud(aud string, cmp string, required bool) bool {
 	if aud == "" {
 		return !required
@@ -105,14 +117,14 @@ func verifyExp(exp int64, now int64, required bool) bool {
 	if exp == 0 {
 		return !required
 	}
-	return now <= exp
+	return now <= cutOff(exp)
 }
 
 func verifyIat(iat int64, now int64, required bool) bool {
 	if iat == 0 {
 		return !required
 	}
-	return now >= iat
+	return now >= cutOff(iat)
 }
 
 func verifyIss(iss string, cmp string, required bool) bool {
@@ -130,5 +142,5 @@ func verifyNbf(nbf int64, now int64, required bool) bool {
 	if nbf == 0 {
 		return !required
 	}
-	return now >= nbf
+	return now >= cutOff(nbf)
 }


### PR DESCRIPTION
as `time.Now().Unix()` returns timestamp with 10 digits,
which records to second unit, we need to cut smaller than
second unit (milisecond, nanosecond) to compare timestamps
with integer comparison.

before this PR, integer comparison with `iat, exp, nbf` and `now`
can make a correct result under assumption that `iat, exp, nbf`
is 10-digits timestamp (which smallest unit is second).
if `iat, exp, nbf` has more digits, `now` is always smaller than
these timestamps, and so always make incorrect verify results.

so i added simple function `func cutOff` which cuts timestamp
to have first 10-digits only, to satisfy that assumption.