### PR TITLE
Adding JWT Audience to support array of audiences

### DIFF
--- a/map_claims.go
+++ b/map_claims.go
@@ -3,7 +3,7 @@ package jwt
 import (
 	"encoding/json"
 	"errors"
-	// "fmt"
+	"reflect"
 )
 
 // Claims type that uses the map[string]interface{} for JSON decoding
@@ -13,8 +13,16 @@ type MapClaims map[string]interface{}
 // Compares the aud claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
-	aud, _ := m["aud"].(string)
-	return verifyAud(aud, cmp, req)
+	auds := m["aud"]
+	if reflect.TypeOf(auds).Kind() == reflect.String {
+		return verifyAud(auds.(string), cmp, req)
+	}
+	for _, aud := range auds.([]interface{}) {
+		if verifyAud(aud.(string), cmp, req) {
+			return true
+		}
+	}
+	return false
 }
 
 // Compares the exp claim against cmp.


### PR DESCRIPTION
Audience claim in JWT should support a list of audiences

Refer https://tools.ietf.org/html/rfc7519#section-4.1.3

> 4.1.3.  "aud" (Audience) Claim
> 
>    The "aud" (audience) claim identifies the recipients that the JWT is
>    intended for.  Each principal intended to process the JWT MUST
>    identify itself with a value in the audience claim.  If the principal
>    processing the claim does not identify itself with a value in the
>    "aud" claim when this claim is present, then the JWT MUST be
>    rejected.  In the general case, the "aud" value is an array of case-
>    sensitive strings, each containing a StringOrURI value.  In the
>    special case when the JWT has one audience, the "aud" value MAY be a
>    single case-sensitive string containing a StringOrURI value.  The
>    interpretation of audience values is generally application specific.
>    Use of this claim is OPTIONAL.