### PR TITLE
fix error strings format

### DIFF
--- a/ecdsa_utils.go
+++ b/ecdsa_utils.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	ErrNotECPublicKey  = errors.New("Key is not a valid ECDSA public key")
-	ErrNotECPrivateKey = errors.New("Key is not a valid ECDSA private key")
+	ErrNotECPublicKey  = errors.New("key is not a valid ECDSA public key")
+	ErrNotECPrivateKey = errors.New("key is not a valid ECDSA private key")
 )
 
 // Parse PEM encoded Elliptic Curve Private Key Structure

--- a/rsa_utils.go
+++ b/rsa_utils.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	ErrKeyMustBePEMEncoded = errors.New("Invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key")
-	ErrNotRSAPrivateKey    = errors.New("Key is not a valid RSA private key")
-	ErrNotRSAPublicKey     = errors.New("Key is not a valid RSA public key")
+	ErrKeyMustBePEMEncoded = errors.New("invalid key: key must be PEM encoded PKCS1 or PKCS8 private key")
+	ErrNotRSAPrivateKey    = errors.New("key is not a valid RSA private key")
+	ErrNotRSAPublicKey     = errors.New("key is not a valid RSA public key")
 )
 
 // Parse PEM encoded PKCS1 or PKCS8 private key


### PR DESCRIPTION
Error strings should not be capitalized or end with punctuation.