### PR TITLE
Refactor parse and validation options API

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -1,9 +1,5 @@
 package jwt
 
-import (
-	"crypto/subtle"
-)
-
 // Claims is the interface used to hold the claims values of a token
 // For a type to be a Claims object, it must have a Valid method that determines
 // if the token is invalid for any supported reason
@@ -27,11 +23,10 @@ type StandardClaims struct {
 	Subject   string       `json:"sub,omitempty"`
 }
 
-// Valid implements Valid from Claims
-// Validates time based claims "exp, iat, nbf".
-// There is no accounting for clock skew.
-// As well, if any of the above claims are not in the token, it will still
-// be considered a valid claim.
+// Valid validates standard claims using ValidationHelper
+// Validates time based claims "exp, nbf" (see: WithLeeway)
+// Validates "aud" if present in claims. (see: WithAudience, WithoutAudienceValidation)
+// Validates "iss" if option is provided (see: WithIssuer)
 func (c StandardClaims) Valid(h *ValidationHelper) error {
 	vErr := new(ValidationError)
 
@@ -49,6 +44,16 @@ func (c StandardClaims) Valid(h *ValidationHelper) error {
 		vErr.Errors |= ValidationErrorNotValidYet
 	}
 
+	if err := h.ValidateAudience(c.Audience); err != nil {
+		vErr.Inner = err
+		vErr.Errors |= ValidationErrorAudience
+	}
+
+	if err := h.ValidateIssuer(c.Issuer); err != nil {
+		vErr.Inner = err
+		vErr.Errors |= ValidationErrorIssuer
+	}
+
 	if vErr.valid() {
 		return nil
 	}
@@ -57,38 +62,11 @@ func (c StandardClaims) Valid(h *ValidationHelper) error {
 }
 
 // VerifyAudience compares the aud claim against cmp.
-// If required is false, this method will return true if the value matches or is unset
-func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
-	return verifyAud(c.Audience, cmp, req)
+func (c *StandardClaims) VerifyAudience(h *ValidationHelper, cmp string) error {
+	return h.ValidateAudienceAgainst(c.Audience, cmp)
 }
 
 // VerifyIssuer compares the iss claim against cmp.
-// If required is false, this method will return true if the value matches or is unset
-func (c *StandardClaims) VerifyIssuer(cmp string, req bool) bool {
-	return verifyIss(c.Issuer, cmp, req)
-}
-
-// ----- helpers
-
-func verifyAud(aud ClaimStrings, cmp string, required bool) bool {
-	if len(aud) == 0 {
-		return !required
-	}
-	for _, audStr := range aud {
-		if subtle.ConstantTimeCompare([]byte(audStr), []byte(cmp)) != 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func verifyIss(iss string, cmp string, required bool) bool {
-	if iss == "" {
-		return !required
-	}
-	if subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0 {
-		return true
-	}
-	return false
-
+func (c *StandardClaims) VerifyIssuer(h *ValidationHelper, cmp string) error {
+	return h.ValidateIssuerAgainst(c.Issuer, cmp)
 }

--- a/claims_test.go
+++ b/claims_test.go
@@ -3,7 +3,6 @@ package jwt_test
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -45,7 +44,7 @@ func TestClaimValidExpired(t *testing.T) {
 		name := data.name
 		t.Logf("\t\tValidate the Claims with exp as %v at time %v", nowInt, expireAt)
 		test.At(time.Unix(nowInt, 0), func() {
-			err := data.claims.Valid()
+			err := data.claims.Valid(nil)
 			t.Log("\t\t\tExpect an error that includes the expired by 1m40s information")
 			if err == nil {
 				t.Errorf("[%v] Expecting error.  Didn't get one.", name)
@@ -64,9 +63,6 @@ func TestClaimValidExpired(t *testing.T) {
 				case *jwt.ExpiredError:
 					if vi.ExpiredBy != 100*time.Second {
 						t.Errorf("[%v] ExpiredError.ExpiredBy %v is not %v\n", name, vi.ExpiredBy, 100*time.Second)
-					}
-					if !reflect.DeepEqual(vi.Claims, data.claims) {
-						t.Errorf("[%v] Claims did not get set in expired error \"%v\"\n", name, vi.Error())
 					}
 					if vi.Error() != "Token is expired" {
 						t.Errorf("[%v] Error message is not as expected \"%v\"\n", name, vi.Error())

--- a/errors.go
+++ b/errors.go
@@ -65,7 +65,6 @@ func (e *ValidationError) valid() bool {
 type ExpiredError struct {
 	Now       int64
 	ExpiredBy time.Duration
-	Claims
 }
 
 func (e *ExpiredError) Error() string {

--- a/map_claims.go
+++ b/map_claims.go
@@ -5,32 +5,28 @@ package jwt
 type MapClaims map[string]interface{}
 
 // VerifyAudience compares the aud claim against cmp.
-// If required is false, this method will return true if the value matches or is unset
-func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
-	aud, ok := m["aud"]
-	if !ok {
-		return !req
+func (m MapClaims) VerifyAudience(h *ValidationHelper, cmp string) error {
+	if aud, err := ParseClaimStrings(m["aud"]); err == nil && aud != nil {
+		return h.ValidateAudienceAgainst(aud, cmp)
+	} else if err != nil {
+		return NewValidationError("couldn't parse 'aud' value", ValidationErrorMalformed)
 	}
-
-	cs, err := ParseClaimStrings(aud)
-	if err != nil {
-		return false
-	}
-
-	return verifyAud(cs, cmp, req)
+	return nil
 }
 
 // VerifyIssuer compares the iss claim against cmp.
-// If required is false, this method will return true if the value matches or is unset
-func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
-	iss, _ := m["iss"].(string)
-	return verifyIss(iss, cmp, req)
+func (m MapClaims) VerifyIssuer(h *ValidationHelper, cmp string) error {
+	iss, ok := m["iss"].(string)
+	if !ok {
+		return NewValidationError("'iss' expected but not present", ValidationErrorIssuer)
+	}
+	return h.ValidateIssuerAgainst(iss, cmp)
 }
 
-// Valid validates time based claims "exp, iat, nbf".
-// There is no accounting for clock skew.
-// As well, if any of the above claims are not in the token, it will still
-// be considered a valid claim.
+// Valid validates standard claims using ValidationHelper
+// Validates time based claims "exp, nbf" (see: WithLeeway)
+// Validates "aud" if present in claims. (see: WithAudience, WithoutAudienceValidation)
+// Validates "iss" if option is provided (see: WithIssuer)
 func (m MapClaims) Valid(h *ValidationHelper) error {
 	vErr := new(ValidationError)
 
@@ -56,6 +52,24 @@ func (m MapClaims) Valid(h *ValidationHelper) error {
 	if err = h.ValidateNotBefore(nbf); err != nil {
 		vErr.Inner = err
 		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	// Try to parse the 'aud' claim
+	if aud, err := ParseClaimStrings(m["aud"]); err == nil && aud != nil {
+		// If it's present and well formed, validate
+		if err = h.ValidateAudience(aud); err != nil {
+			vErr.Inner = err
+			vErr.Errors |= ValidationErrorAudience
+		}
+	} else if err != nil {
+		// If it's present and not well formed, return an error
+		return NewValidationError("couldn't parse 'aud' value", ValidationErrorMalformed)
+	}
+
+	iss, _ := m["iss"].(string)
+	if err = h.ValidateIssuer(iss); err != nil {
+		vErr.Inner = err
+		vErr.Errors |= ValidationErrorIssuer
 	}
 
 	if vErr.valid() {

--- a/parser.go
+++ b/parser.go
@@ -5,20 +5,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 )
 
 // Parser is the type used to parse and validate a JWT token from string
 type Parser struct {
-	validMethods         []string      // If populated, only these methods will be considered valid
-	useJSONNumber        bool          // Use JSON Number format in JSON decoder
-	skipClaimsValidation bool          // Skip claims validation during token parsing
-	leeway               time.Duration // Amount of leeway to provide when comparing time values
+	validMethods         []string // If populated, only these methods will be considered valid
+	useJSONNumber        bool     // Use JSON Number format in JSON decoder
+	skipClaimsValidation bool     // Skip claims validation during token parsing
+	*ValidationHelper
 }
 
 // NewParser returns a new Parser with the specified options
 func NewParser(options ...ParserOption) *Parser {
-	p := new(Parser)
+	p := &Parser{
+		ValidationHelper: new(ValidationHelper),
+	}
 	for _, option := range options {
 		option(p)
 	}
@@ -80,8 +81,7 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 
 	// Validate Claims
 	if !p.skipClaimsValidation && vErr.valid() {
-		helper := p.GetValidationHelper()
-		if err := token.Claims.Valid(helper); err != nil {
+		if err := token.Claims.Valid(p.ValidationHelper); err != nil {
 
 			// If the Claims Valid returned an error, check if it is a validation error,
 			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
@@ -160,12 +160,4 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	}
 
 	return token, parts, nil
-}
-
-// GetValidationHelper creates a *ValidationHelper, passing along all relevant
-// ParserOption values
-func (p *Parser) GetValidationHelper() *ValidationHelper {
-	return &ValidationHelper{
-		leeway: p.leeway,
-	}
 }

--- a/parser.go
+++ b/parser.go
@@ -9,9 +9,18 @@ import (
 
 // Parser is the type used to parse and validate a JWT token from string
 type Parser struct {
-	ValidMethods         []string // If populated, only these methods will be considered valid
-	UseJSONNumber        bool     // Use JSON Number format in JSON decoder
-	SkipClaimsValidation bool     // Skip claims validation during token parsing
+	validMethods         []string // If populated, only these methods will be considered valid
+	useJSONNumber        bool     // Use JSON Number format in JSON decoder
+	skipClaimsValidation bool     // Skip claims validation during token parsing
+}
+
+// NewParser returns a new Parser with the specified options
+func NewParser(options ...ParserOption) *Parser {
+	p := new(Parser)
+	for _, option := range options {
+		option(p)
+	}
+	return p
 }
 
 // Parse will parse, validate, and return a token.
@@ -29,10 +38,10 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 	}
 
 	// Verify signing method is in the required set
-	if p.ValidMethods != nil {
+	if p.validMethods != nil {
 		var signingMethodValid = false
 		var alg = token.Method.Alg()
-		for _, m := range p.ValidMethods {
+		for _, m := range p.validMethods {
 			if m == alg {
 				signingMethodValid = true
 				break
@@ -68,7 +77,7 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 	}
 
 	// Validate Claims
-	if !p.SkipClaimsValidation && vErr.valid() {
+	if !p.skipClaimsValidation && vErr.valid() {
 		if err := token.Claims.Valid(); err != nil {
 
 			// If the Claims Valid returned an error, check if it is a validation error,
@@ -124,7 +133,7 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
 	}
 	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
-	if p.UseJSONNumber {
+	if p.useJSONNumber {
 		dec.UseNumber()
 	}
 	// JSON Decode.  Special case for map type to avoid weird pointer behavior

--- a/parser_option.go
+++ b/parser_option.go
@@ -31,10 +31,11 @@ func WithoutClaimsValidation() ParserOption {
 	}
 }
 
-// WithLeeway returns the ParserOption for specifying the
-// leeway window.
+// WithLeeway returns the ParserOption for specifying the leeway window.
 func WithLeeway(d time.Duration) ParserOption {
 	return func(p *Parser) {
-		p.leeway = d
+		p.ValidationHelper.leeway = d
+	}
+}
 	}
 }

--- a/parser_option.go
+++ b/parser_option.go
@@ -1,0 +1,30 @@
+package jwt
+
+// ParserOption implements functional options for parser behavior
+// see: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
+type ParserOption func(*Parser)
+
+// WithValidMethods returns the ParserOption for specifying valid signing methods
+func WithValidMethods(valid []string) ParserOption {
+	return func(p *Parser) {
+		p.validMethods = valid
+	}
+}
+
+// WithJSONNumber returns the ParserOption for using json.Number instead of float64 when parsing
+// numeric values. Used most commonly with MapClaims, but it can be useful in some cases with
+// structured claims types
+func WithJSONNumber() ParserOption {
+	return func(p *Parser) {
+		p.useJSONNumber = true
+	}
+}
+
+// WithoutClaimsValidation returns the ParserOption for disabling claims validation
+// This does not disable signature validation. Use this if you want intend to implement
+// claims validation via other means
+func WithoutClaimsValidation() ParserOption {
+	return func(p *Parser) {
+		p.skipClaimsValidation = true
+	}
+}

--- a/parser_option.go
+++ b/parser_option.go
@@ -1,5 +1,7 @@
 package jwt
 
+import "time"
+
 // ParserOption implements functional options for parser behavior
 // see: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
 type ParserOption func(*Parser)
@@ -26,5 +28,13 @@ func WithJSONNumber() ParserOption {
 func WithoutClaimsValidation() ParserOption {
 	return func(p *Parser) {
 		p.skipClaimsValidation = true
+	}
+}
+
+// WithLeeway returns the ParserOption for specifying the
+// leeway window.
+func WithLeeway(d time.Duration) ParserOption {
+	return func(p *Parser) {
+		p.leeway = d
 	}
 }

--- a/parser_option.go
+++ b/parser_option.go
@@ -37,5 +37,24 @@ func WithLeeway(d time.Duration) ParserOption {
 		p.ValidationHelper.leeway = d
 	}
 }
+
+// WithAudience returns the ParserOption for specifying an expected aud member value
+func WithAudience(aud string) ParserOption {
+	return func(p *Parser) {
+		p.ValidationHelper.audience = &aud
+	}
+}
+
+// WithoutAudienceValidation returns the ParserOption that specifies audience check should be skipped
+func WithoutAudienceValidation() ParserOption {
+	return func(p *Parser) {
+		p.ValidationHelper.skipAudience = true
+	}
+}
+
+// WithIssuer returns the ParserOption that specifies a value to compare against the iss claim
+func WithIssuer(iss string) ParserOption {
+	return func(p *Parser) {
+		p.ValidationHelper.issuer = &iss
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -72,6 +72,15 @@ var jwtTestData = []struct {
 		nil,
 	},
 	{
+		"expired and nbf with leeway",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 50), "exp": float64(time.Now().Unix() - 50)},
+		true,
+		0,
+		jwt.NewParser(jwt.WithLeeway(100 * time.Second)),
+	},
+	{
 		"basic invalid",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.EhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
 		defaultKeyFunc,

--- a/parser_test.go
+++ b/parser_test.go
@@ -114,7 +114,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorSignatureInvalid,
-		&jwt.Parser{ValidMethods: []string{"HS256"}},
+		jwt.NewParser(jwt.WithValidMethods([]string{"HS256"})),
 	},
 	{
 		"valid signing method",
@@ -123,7 +123,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		true,
 		0,
-		&jwt.Parser{ValidMethods: []string{"RS256", "HS256"}},
+		jwt.NewParser(jwt.WithValidMethods([]string{"RS256", "HS256"})),
 	},
 	{
 		"JSON Number",
@@ -132,7 +132,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": json.Number("123.4")},
 		true,
 		0,
-		&jwt.Parser{UseJSONNumber: true},
+		jwt.NewParser(jwt.WithJSONNumber()),
 	},
 	{
 		"Standard Claims",
@@ -143,7 +143,7 @@ var jwtTestData = []struct {
 		},
 		true,
 		0,
-		&jwt.Parser{UseJSONNumber: true},
+		jwt.NewParser(jwt.WithJSONNumber()),
 	},
 	{
 		"JSON Number - basic expired",
@@ -152,7 +152,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
 		false,
 		jwt.ValidationErrorExpired,
-		&jwt.Parser{UseJSONNumber: true},
+		jwt.NewParser(jwt.WithJSONNumber()),
 	},
 	{
 		"JSON Number - basic nbf",
@@ -161,7 +161,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
 		false,
 		jwt.ValidationErrorNotValidYet,
-		&jwt.Parser{UseJSONNumber: true},
+		jwt.NewParser(jwt.WithJSONNumber()),
 	},
 	{
 		"JSON Number - expired and nbf",
@@ -170,7 +170,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100)), "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
 		false,
 		jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired,
-		&jwt.Parser{UseJSONNumber: true},
+		jwt.NewParser(jwt.WithJSONNumber()),
 	},
 	{
 		"SkipClaimsValidation during token parsing",
@@ -179,7 +179,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
 		true,
 		0,
-		&jwt.Parser{UseJSONNumber: true, SkipClaimsValidation: true},
+		jwt.NewParser(jwt.WithJSONNumber(), jwt.WithoutClaimsValidation()),
 	},
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -190,6 +190,78 @@ var jwtTestData = []struct {
 		0,
 		jwt.NewParser(jwt.WithJSONNumber(), jwt.WithoutClaimsValidation()),
 	},
+	{
+		"Audience - Required",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"aud": []interface{}{"foo", "bar"}},
+		false,
+		jwt.ValidationErrorAudience,
+		jwt.NewParser(),
+	},
+	{
+		"Audience - Ignored",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"aud": []interface{}{"foo", "bar"}},
+		true,
+		0,
+		jwt.NewParser(jwt.WithoutAudienceValidation()),
+	},
+	{
+		"Audience - Pass",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"aud": []interface{}{"foo", "bar"}},
+		true,
+		0,
+		jwt.NewParser(jwt.WithAudience("foo")),
+	},
+	{
+		"Audience - Fail",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"aud": []interface{}{"foo", "bar"}},
+		false,
+		jwt.ValidationErrorAudience,
+		jwt.NewParser(jwt.WithAudience("baz")),
+	},
+	{
+		"Issuer - Pass",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"iss": "foo"},
+		true,
+		0,
+		jwt.NewParser(jwt.WithIssuer("foo")),
+	},
+	{
+		"Issuer - Fail",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"iss": "foo"},
+		false,
+		jwt.ValidationErrorIssuer,
+		jwt.NewParser(jwt.WithIssuer("bar")),
+	},
+	{
+		"Issuer - Provided but not in claims",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{},
+		false,
+		jwt.ValidationErrorIssuer,
+		jwt.NewParser(jwt.WithIssuer("bar")),
+	},
+	{
+		"Issuer - Ignored",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"iss": "foo"},
+		true,
+		0,
+		jwt.NewParser(),
+	},
 }
 
 func TestParser_Parse(t *testing.T) {

--- a/token.go
+++ b/token.go
@@ -81,13 +81,13 @@ func (t *Token) SigningString() (string, error) {
 // keyFunc will receive the parsed token and should return the key for validating.
 // If everything is kosher, err will be nil
 // Claims type will be the default, MapClaims
-func Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
-	return new(Parser).Parse(tokenString, keyFunc)
+func Parse(tokenString string, keyFunc Keyfunc, options ...ParserOption) (*Token, error) {
+	return NewParser(options...).Parse(tokenString, keyFunc)
 }
 
 // ParseWithClaims is Parse, but with a specified Claims type
-func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
-	return new(Parser).ParseWithClaims(tokenString, claims, keyFunc)
+func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc, options ...ParserOption) (*Token, error) {
+	return NewParser(options...).ParseWithClaims(tokenString, claims, keyFunc)
 }
 
 // EncodeSegment is used internally for JWT specific base64url encoding with padding stripped

--- a/validation_helper.go
+++ b/validation_helper.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"time"
 )
@@ -10,9 +11,15 @@ var DefaultValidationHelper = &ValidationHelper{}
 
 // ValidationHelper is built by the parser and passed
 // to Claims.Value to carry parse/validation options
+// This standalone type exists to allow implementations to do whatever custom
+// behavior is required while still being able to call upon the standard behavior
+// as necessary.
 type ValidationHelper struct {
 	nowFunc      func() time.Time // Override for time.Now. Mostly used for testing
 	leeway       time.Duration    // Leeway to provide when validating time values
+	audience     *string          // Expected audience value
+	skipAudience bool             // Ignore aud check
+	issuer       *string          // Expected issuer value. ignored if nil
 }
 
 // NewValidationHelper creates a validation helper from a list of parser options
@@ -75,4 +82,69 @@ func (h *ValidationHelper) ValidateNotBefore(nbf *Time) error {
 	}
 	// Nbf has been reached. valid.
 	return nil
+}
+
+// ValidateAudience verifies that aud contains the audience value provided
+// by the WithAudience option.
+// Per the spec (https://tools.ietf.org/html/rfc7519#section-4.1.3), if the aud
+// claim is present,
+func (h *ValidationHelper) ValidateAudience(aud ClaimStrings) error {
+	// Skip flag
+	if h.skipAudience {
+		return nil
+	}
+
+	// If there's no audience claim, ignore
+	if aud == nil || len(aud) == 0 {
+		return nil
+	}
+
+	// If there is an audience claim, but no value provided, fail
+	if h.audience == nil {
+		return NewValidationError("audience value was expected but not provided", ValidationErrorAudience)
+	}
+
+	return h.ValidateAudienceAgainst(aud, *h.audience)
+}
+
+// ValidateAudienceAgainst checks that the compare value is included in the aud list
+// It is used by ValidateAudience, but exposed as a helper for other implementations
+func (h *ValidationHelper) ValidateAudienceAgainst(aud ClaimStrings, compare string) error {
+	if aud == nil {
+		return nil
+	}
+
+	// Compare provided value with aud claim.
+	// This code avoids the early return to make this check more or less constant time.
+	// I'm not certain that's actually required in this context.
+	var match = false
+	for _, audStr := range aud {
+		if subtle.ConstantTimeCompare([]byte(audStr), []byte(compare)) == 1 {
+			match = true
+		}
+	}
+	if !match {
+		return NewValidationError(fmt.Sprintf("'%v' wasn't found in aud claim", compare), ValidationErrorAudience)
+	}
+	return nil
+
+}
+
+// ValidateIssuer checks the claim value against the value provided by WithIssuer
+func (h *ValidationHelper) ValidateIssuer(iss string) error {
+	// Always passes validation if issuer is not provided
+	if h.issuer == nil {
+		return nil
+	}
+
+	return h.ValidateIssuerAgainst(iss, *h.issuer)
+}
+
+// ValidateIssuerAgainst checks the claim value against the value provided, ignoring the WithIssuer value
+func (h *ValidationHelper) ValidateIssuerAgainst(iss string, compare string) error {
+	if subtle.ConstantTimeCompare([]byte(iss), []byte(compare)) == 1 {
+		return nil
+	}
+
+	return NewValidationError("'iss' value doesn't match expectation", ValidationErrorIssuer)
 }

--- a/validation_helper.go
+++ b/validation_helper.go
@@ -11,16 +11,17 @@ var DefaultValidationHelper = &ValidationHelper{}
 // ValidationHelper is built by the parser and passed
 // to Claims.Value to carry parse/validation options
 type ValidationHelper struct {
-	nowFunc func() time.Time
-	leeway  time.Duration
+	nowFunc      func() time.Time // Override for time.Now. Mostly used for testing
+	leeway       time.Duration    // Leeway to provide when validating time values
 }
 
 // NewValidationHelper creates a validation helper from a list of parser options
 // Not all parser options will impact validation
-// You are usually probably better off creating a custom parser and using GetValidationHelper
+// If you already have a custom parser, you can use its ValidationHelper value
+// instead of creating a new one
 func NewValidationHelper(options ...ParserOption) *ValidationHelper {
 	p := NewParser(options...)
-	return p.GetValidationHelper()
+	return p.ValidationHelper
 }
 
 func (h *ValidationHelper) now() time.Time {

--- a/validation_helper.go
+++ b/validation_helper.go
@@ -1,0 +1,69 @@
+package jwt
+
+import (
+	"fmt"
+	"time"
+)
+
+// DefaultValidationHelper is used by Claims.Valid if none is provided
+var DefaultValidationHelper = &ValidationHelper{}
+
+// ValidationHelper is built by the parser and passed
+// to Claims.Value to carry parse/validation options
+type ValidationHelper struct {
+	nowFunc func() time.Time
+	leeway  time.Duration
+}
+
+func (h *ValidationHelper) now() time.Time {
+	if h.nowFunc != nil {
+		return h.nowFunc()
+	}
+	return TimeFunc()
+}
+
+// Before returns true if Now is before t
+// Takes leeway into account
+func (h *ValidationHelper) Before(t time.Time) bool {
+	return h.now().Before(t.Add(-h.leeway))
+}
+
+// After returns true if Now is after t
+// Takes leeway into account
+func (h *ValidationHelper) After(t time.Time) bool {
+	return h.now().After(t.Add(h.leeway))
+}
+
+// ValidateExpiresAt returns an error if the expiration time is invalid
+// Takes leeway into account
+func (h *ValidationHelper) ValidateExpiresAt(exp *Time) error {
+	// 'exp' claim is not set. ignore.
+	if exp == nil {
+		return nil
+	}
+
+	// Expiration has passed
+	if h.After(exp.Time) {
+		delta := h.now().Sub(exp.Time)
+		return &ExpiredError{h.now().Unix(), delta}
+	}
+
+	// Expiration has not passed
+	return nil
+}
+
+// ValidateNotBefore returns an error if the nbf time has not been reached
+// Takes leeway into account
+func (h *ValidationHelper) ValidateNotBefore(nbf *Time) error {
+	// 'nbf' claim is not set. ignore.
+	if nbf == nil {
+		return nil
+	}
+
+	// Nbf hasn't been reached
+	if h.Before(nbf.Time) {
+		return fmt.Errorf("token is not valid yet")
+	}
+	// Nbf has been reached. valid.
+	return nil
+}

--- a/validation_helper.go
+++ b/validation_helper.go
@@ -15,6 +15,14 @@ type ValidationHelper struct {
 	leeway  time.Duration
 }
 
+// NewValidationHelper creates a validation helper from a list of parser options
+// Not all parser options will impact validation
+// You are usually probably better off creating a custom parser and using GetValidationHelper
+func NewValidationHelper(options ...ParserOption) *ValidationHelper {
+	p := NewParser(options...)
+	return p.GetValidationHelper()
+}
+
 func (h *ValidationHelper) now() time.Time {
 	if h.nowFunc != nil {
 		return h.nowFunc()


### PR DESCRIPTION
- [x] Replace exposed values in Parser struct with functional style ParserOptions provided at creation
- [x] Replace redundant validation methods between `StandardClaims` and `MapClaims` with a new `ValidationHelper` type
- [x] Propagate relevant `ParserOption`s from `Parser` to `ValidationHelper`
- [x] Replace redundant error creation with new helper method behavior
- [x] Add support for leeway through new `ParserOption`
- [x] Add support for validating remaining standard claims via `ParserOption`s