### PR TITLE
Changed error msg to not be misleading for public key decoding errors

### DIFF
--- a/rsa_utils.go
+++ b/rsa_utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	ErrKeyMustBePEMEncoded = errors.New("Invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key")
+	ErrKeyMustBePEMEncoded = errors.New("Invalid Key: Key must be a PEM encoded PKCS1 or PKCS8 key")
 	ErrNotRSAPrivateKey    = errors.New("Key is not a valid RSA private key")
 	ErrNotRSAPublicKey     = errors.New("Key is not a valid RSA public key")
 )


### PR DESCRIPTION
The error msg of "Key must be a PEM encoded PKCS1 or PKCS8 private key" was being used when decoding public keys as well. This caused confusion when handling failures with decoding public keys.

https://github.com/dgrijalva/jwt-go/blob/06ea1031745cb8b3dab3f6a236daf2b0aa468b7e/rsa_utils.go#L81
