### PR TITLE
Add ECDSA pkcs8 parser

### DIFF
--- a/ecdsa_utils.go
+++ b/ecdsa_utils.go
@@ -25,7 +25,9 @@ func ParseECPrivateKeyFromPEM(key []byte) (*ecdsa.PrivateKey, error) {
 	// Parse the key
 	var parsedKey interface{}
 	if parsedKey, err = x509.ParseECPrivateKey(block.Bytes); err != nil {
-		return nil, err
+		if parsedKey, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+			return nil, err
+		}
 	}
 
 	var pkey *ecdsa.PrivateKey


### PR DESCRIPTION
Added it because could not parse ECDSA pkcs#8 private key.