### PR TITLE
fix missing check error, preventing nil pointer dereference panic

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -67,6 +67,11 @@ func ExampleParseWithClaims_customClaimsType() {
 			return []byte("AllYourBase"), nil
 		})
 
+		if err != nil {
+			fmt.Println("invalid tokenString")
+			return
+		}
+
 		if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
 			fmt.Printf("%v %v", claims.Foo, claims.StandardClaims.ExpiresAt)
 		} else {
@@ -94,6 +99,11 @@ func ExampleParse_errorChecking() {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	})
+
+	if err != nil {
+		fmt.Println("invalid tokenString")
+		return
+	}
 
 	if token.Valid {
 		fmt.Println("You look nice today")


### PR DESCRIPTION
based on issue #379, I added error check to make examples more clarifying for new users. 