### PR TITLE
Use RawURLEncoding instead of padding trimming/appending

### DIFF
--- a/token.go
+++ b/token.go
@@ -95,14 +95,10 @@ func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token
 
 // Encode JWT specific base64url encoding with padding stripped
 func EncodeSegment(seg []byte) string {
-	return strings.TrimRight(base64.URLEncoding.EncodeToString(seg), "=")
+	return base64.RawURLEncoding.EncodeToString(seg)
 }
 
 // Decode JWT specific base64url encoding with padding stripped
 func DecodeSegment(seg string) ([]byte, error) {
-	if l := len(seg) % 4; l > 0 {
-		seg += strings.Repeat("=", 4-l)
-	}
-
-	return base64.URLEncoding.DecodeString(seg)
+	return base64.RawURLEncoding.DecodeString(seg)
 }


### PR DESCRIPTION
This change decreases number of allocations needed for token encoding/decoding.