### PR TITLE
Added a fuzzer

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,19 @@
+package jwt
+
+import (
+	"crypto/rsa"
+)
+
+var (
+	jwtTestDefaultKey *rsa.PublicKey
+	defaultKeyFunc    Keyfunc = func(t *Token) (interface{}, error) { return jwtTestDefaultKey, nil }
+)
+
+func Fuzz(data []byte) int {
+	parser := Parser{UseJSONNumber: true}
+	_, err := parser.Parse(string(data), defaultKeyFunc)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer for the parser.
If there is interest for fuzzing jwt-go, I will be happy to add more fuzzers and setup continuous fuzzing through oss-fuzz. This will allow Google to run the fuzzers continuously and send bug reports if bugs are found. It is a free service that is offered with an implied expectation that bugs are fixed, so that the resources spent on fuzzing jwt-go are well spent.
To setup continuous fuzzing, all I need are the emails for the bug reports. These will be added to a public list that can be changed anytime.