### PR TITLE
Fix issue where unwrapped errors are nil

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -34,12 +34,12 @@ func wrapError(a, b error) error {
 type ErrorWrapper struct{ err error }
 
 // Unwrap implements xerrors.Wrapper
-func (w ErrorWrapper) Unwrap() error {
+func (w *ErrorWrapper) Unwrap() error {
 	return w.err
 }
 
 // Wrap stores the provided error value and returns it when Unwrap is called
-func (w ErrorWrapper) Wrap(err error) {
+func (w *ErrorWrapper) Wrap(err error) {
 	w.err = err
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,13 @@
+package jwt
+
+import "testing"
+
+func TestErrorWrapper_Unwrap(t *testing.T) {
+	err1 := &UnverfiableTokenError{}
+	err2 := &InvalidSignatureError{}
+	err1.Wrap(err2)
+	unwrapped := err1.Unwrap()
+	if unwrapped != err2 {
+		t.Errorf("Unwrapped error was not expected value.")
+	}
+}


### PR DESCRIPTION
When wrapping and unwrapping an error using the embedded `ErrorWrapper` type, the unwrapped error was nil which made it impossible to determine the error that was returned from the `Keyfunc`.