### PR TITLE
Added power support to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: go
 script:
     - go vet ./...
     - go test -v ./...
-
+arch:
+  - AMD64
+  - ppc64le
 go:
   - 1.3
   - 1.4
@@ -11,3 +13,10 @@ go:
   - 1.6
   - 1.7
   - tip
+# Disable version 1.3, 1.4
+jobs: 
+  exclude:
+    - arch: ppc64le
+      go: 1.3
+    - arch: ppc64le
+      go: 1.4


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le and excluded jobs which are not supported for ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.