### PR TITLE
non api breaking fix to MapClaims VerifyAudience

### DIFF
--- a/claims_test.go
+++ b/claims_test.go
@@ -1,0 +1,68 @@
+package jwt
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStandardClaims_VerifyAud(t *testing.T) {
+	var testCases = []struct {
+		name                 string
+		givenToken           string
+		whenRequired         bool
+		expectUnmarshalError bool
+		expect               bool
+	}{
+		{
+			name:         "nok, require, aud is missing",
+			givenToken:   `{}`,
+			whenRequired: true,
+			expect:       false,
+		},
+		{
+			name:         "ok, optional, aud is missing",
+			givenToken:   `{}`,
+			whenRequired: false,
+			expect:       true,
+		},
+		{
+			name:         "ok, required, aud is matching",
+			givenToken:   `{"aud": "myaud"}`,
+			whenRequired: true,
+			expect:       true,
+		},
+		{
+			name:         "ok, optional, aud is matching",
+			givenToken:   `{"aud": "myaud"}`,
+			whenRequired: false,
+			expect:       true,
+		},
+		{
+			name:                 "impossible when aud is array",
+			givenToken:           `{"aud": ["site"]}`,
+			expectUnmarshalError: true,
+		},
+		{
+			name:                 "impossible when aud is empty array",
+			givenToken:           `{"aud": []}`,
+			expectUnmarshalError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var claims StandardClaims
+			if err := json.Unmarshal([]byte(tc.givenToken), &claims); err != nil {
+				if tc.expectUnmarshalError {
+					return
+				}
+				t.Fatal(err)
+			}
+
+			result := claims.VerifyAudience("myaud", tc.whenRequired)
+			if tc.expect != result {
+				t.Fatalf("expect != result")
+			}
+		})
+	}
+}

--- a/map_claim_test.go
+++ b/map_claim_test.go
@@ -1,0 +1,94 @@
+package jwt
+
+import "testing"
+
+func TestMapClaims_VerifyAudience(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		givenClaims  MapClaims
+		whenRequired bool
+		expect       bool
+	}{
+		{
+			name:         "ok, string, required and aud is matching",
+			givenClaims:  MapClaims{"aud": "mysite"},
+			whenRequired: true,
+			expect:       true,
+		},
+		{
+			name:         "ok, string, optional and aud is matching",
+			givenClaims:  MapClaims{"aud": "mysite"},
+			whenRequired: false,
+			expect:       true,
+		},
+		{
+			name:         "ok, optional and aud is missing",
+			givenClaims:  MapClaims{},
+			whenRequired: false,
+			expect:       true,
+		},
+		{
+			name:         "nok, required and aud is missing",
+			givenClaims:  MapClaims{},
+			whenRequired: true,
+			expect:       false,
+		},
+		{
+			name:         "ok, string, optional and aud is empty",
+			givenClaims:  MapClaims{"aud": ""},
+			whenRequired: false,
+			expect:       true,
+		},
+		{
+			name:         "nok, string, optional and aud is not matching",
+			givenClaims:  MapClaims{"aud": "not matching"},
+			whenRequired: false,
+			expect:       false,
+		},
+		{
+			name:         "nok, string, required and aud is empty",
+			givenClaims:  MapClaims{"aud": ""},
+			whenRequired: true,
+			expect:       false,
+		},
+		{
+			name:         "ok, array, optional and aud is matching",
+			givenClaims:  MapClaims{"aud": []string{"not-matching", "yet not matching", "mysite"}},
+			whenRequired: false,
+			expect:       true,
+		},
+		{
+			name:         "ok, array, optional and aud is empty",
+			givenClaims:  MapClaims{"aud": []string{}},
+			whenRequired: false,
+			expect:       true,
+		},
+		{
+			name:         "nok, array, optional and aud is not matching",
+			givenClaims:  MapClaims{"aud": []string{"not-matching"}},
+			whenRequired: false,
+			expect:       false,
+		},
+		{
+			name:         "ok, array, required and aud is matching",
+			givenClaims:  MapClaims{"aud": []string{"not-matching", "yet not matching", "mysite"}},
+			whenRequired: true,
+			expect:       true,
+		},
+		{
+			name:         "nok, array, required and aud is matching",
+			givenClaims:  MapClaims{"aud": []string{"not-matching", "yet not matching"}},
+			whenRequired: true,
+			expect:       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.givenClaims.VerifyAudience("mysite", tc.whenRequired)
+			if tc.expect != result {
+				t.Error("expected != result")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is non api breaking fix to MapClaims VerifyAudience problem.  This could be release as patch version v3.2.1 

See these comments;
https://github.com/dgrijalva/jwt-go/issues/463#issuecomment-854975451
https://github.com/dgrijalva/jwt-go/issues/463#issuecomment-854979458

this does not change `StandardClaims.Audience` type as it not a actual problem for `StandardClaims.VerifyAudience`. Go type system will not allow slice to assigned to string. Problematic part is `MapClaims.VerifyAudience` which is handling intefaces