### PR TITLE
add deprecated message to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+// Deprecated: use github.com/golang-jwt/jwt instead.
+module github.com/dgrijalva/jwt-go
+
+go 1.17


### PR DESCRIPTION
README says "THIS REPOSITORY IS NO LONGER MAINTANED", however many modules still import this repository.

- https://pkg.go.dev/github.com/dgrijalva/jwt-go?tab=importedby

Module deprecation comments are available from Go 1.17: https://golang.org/doc/go1.17
The comment notify the deprecated message to the users.