### PR TITLE
The verification of the token's legitimate signature should precede the content

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -58,10 +58,16 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 
 	vErr := &ValidationError{}
 
+	// Perform validation
+	token.Signature = parts[2]
+	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
+		vErr.Inner = err
+		vErr.Errors |= ValidationErrorSignatureInvalid
+	}
+
 	// Validate Claims
 	if !p.SkipClaimsValidation {
 		if err := token.Claims.Valid(); err != nil {
-
 			// If the Claims Valid returned an error, check if it is a validation error,
 			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
 			if e, ok := err.(*ValidationError); !ok {
@@ -70,13 +76,6 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 				vErr = e
 			}
 		}
-	}
-
-	// Perform validation
-	token.Signature = parts[2]
-	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
-		vErr.Inner = err
-		vErr.Errors |= ValidationErrorSignatureInvalid
 	}
 
 	if vErr.valid() {


### PR DESCRIPTION
The verification of the token's legitimate signature should precede the content
Usually when the token is about to expire, we issue a new token. The previous logic allows an attacker to cheat a legitimate token with a forged token

工具翻译，不知道你能不能看得懂